### PR TITLE
Fix startup validation and tests

### DIFF
--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -6,19 +6,18 @@ import shell from "shelljs";
 import builder from "../../builder";
 import { Dashboard } from "../../dashboard";
 import { createRuntimeHost } from "../../runtimeHost";
-import { GithubActionSWAConfig, isPortAvailable, parseUrl, readConfigFile } from "../../utils";
+import { GithubActionSWAConfig, isAcceptingTcpConnections, isHttpUrl, isPortAvailable, parseUrl, readConfigFile } from "../../utils";
 import { DEFAULT_CONFIG } from "../config";
 
 export async function start(startContext: string, program: CommanderStatic) {
-  if (startContext.startsWith("http")) {
+  if (isHttpUrl(startContext)) {
     // start the emulator and proxy app to the provided uri
-    let { host, port } = parseUrl(startContext);
-    port = port || 4280;
+    let { hostname, port } = parseUrl(startContext);
 
     // make sure host and port are available
     try {
-      const portAvailable = await isPortAvailable({ port, host });
-      if (portAvailable) {
+      const appListening = await isAcceptingTcpConnections({ port, host: hostname });
+      if (appListening ===  false) {
         console.info(`INFO: Could not connect to "${startContext}". Is the server up and running?`);
         process.exit(0);
       } else {

--- a/src/runtimeHost.spec.ts
+++ b/src/runtimeHost.spec.ts
@@ -26,7 +26,7 @@ describe("runtimeHost", () => {
       });
 
       expect(spyDetectRuntime).toHaveBeenCalledWith("./");
-      expect(rh.command).toContain(path.join("swa-emulator", "node_modules", ".bin", "http-server"));
+      expect(rh.command).toContain(path.join(process.cwd(), "node_modules", ".bin", "http-server"));
       expect(rh.args).toEqual(["./foobar", "--port", "8080", "--cache", "-1", "--proxy", "http://0.0.0.0:4242/?"]);
     });
 
@@ -37,7 +37,7 @@ describe("runtimeHost", () => {
       });
 
       expect(spyDetectRuntime).toHaveBeenCalledWith("./");
-      expect(rh.command).toContain(path.join("swa-emulator", "node_modules", ".bin", "http-server"));
+      expect(rh.command).toContain(path.join(process.cwd(), "node_modules", ".bin", "http-server"));
       expect(rh.args).toEqual(["./", "--port", "8080", "--cache", "-1", "--proxy", "http://0.0.0.0:4242/?"]);
     });
 
@@ -48,7 +48,7 @@ describe("runtimeHost", () => {
       });
 
       expect(spyDetectRuntime).toHaveBeenCalledWith("./");
-      expect(rh.command).toContain(path.join("swa-emulator", "node_modules", ".bin", "http-server"));
+      expect(rh.command).toContain(path.join(process.cwd(), "node_modules", ".bin", "http-server"));
       expect(rh.args).toEqual(["./", "--port", "8080", "--cache", "-1", "--proxy", "http://127.0.0.1:4242/?"]);
     });
 
@@ -59,7 +59,7 @@ describe("runtimeHost", () => {
       });
 
       expect(spyDetectRuntime).toHaveBeenCalledWith("./");
-      expect(rh.command).toContain(path.join("swa-emulator", "node_modules", ".bin", "http-server"));
+      expect(rh.command).toContain(path.join(process.cwd(), "node_modules", ".bin", "http-server"));
       expect(rh.args).toEqual(["./", "--port", "8080", "--cache", "-1", "--proxy", "http://0.0.0.0:3000/?"]);
     });
 
@@ -70,7 +70,7 @@ describe("runtimeHost", () => {
       });
 
       expect(spyDetectRuntime).toHaveBeenCalledWith("./foobar");
-      expect(rh.command).toContain(path.join("swa-emulator", "node_modules", ".bin", "http-server"));
+      expect(rh.command).toContain(path.join(process.cwd(), "node_modules", ".bin", "http-server"));
       expect(rh.args).toEqual(["./", "--port", "8080", "--cache", "-1", "--proxy", "http://0.0.0.0:4242/?"]);
     });
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -290,6 +290,32 @@ export function argv<T extends string | number | boolean | null>(flag: string): 
 
   return null as T;
 }
+
+export function isAcceptingTcpConnections({ host = "127.0.0.1", port }: { host?: string; port: number }) {
+  return new Promise<boolean>((resolve) => {
+    const socket = net.createConnection(port, host);
+
+    socket
+      .once("error", () => {
+        resolve(false);
+        socket.end();
+      })
+      .once("connect", () => {
+        resolve(true);
+        socket.end();
+      })
+  });
+}
+
+export function isHttpUrl(input: string) {
+  try {
+    const url = new URL(input);
+    return url.protocol.startsWith("http");
+  } catch {
+    return false;
+  }
+}
+
 export async function isPortAvailable({ host = "127.0.0.1", port }: { host?: string; port: number }) {
   return new Promise<boolean>((resolve, reject) => {
     const server = net.createServer();


### PR DESCRIPTION
Fixes some issues that prevented #41 from working on my machine/setup.

I have a create-react-app app running, listening to localhost:3000. However, `isPortAvailable()` was still returning `true`. 😕 Changed the code to test using a TCP connection instead.

Fixed some tests that were failing because they depended on the name of the folder. They no longer work after the repo was renamed.