### PR TITLE
Fix startup issues and WebSocket forwarding

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ If you need to override the default values, provide the following options:
 | Options                          | Description                                  | Default     | Example                       |
 | -------------------------------- | -------------------------------------------- | ----------- | ----------------------------- |
 | `--app, --app-artifact-location` | set app artifact (dist) folder or dev server | `./`        | `--app=./my-dist`             |
-| `--api, --api-artifact-location` | set the API folder or dev server             | `./api`     | `--api=http://localhost:8083` |
+| `--api, --api-artifact-location` | set the API folder or dev server             |             | `--api=http://localhost:8083` |
 | `--auth-port`                    | set the Auth server port                     | `4242`      | `--auth-port=8083`            |
 | `--api-port`                     | set the API server port                      | `7071`      | `--api-port=8082`             |
 | `--app-port`                     | set the app server port                      | `4200`      | `--app-port=8081`             |

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -80,7 +80,7 @@ export async function start(startContext: string, program: CLIConfig) {
     serveStaticContent = `${hostCommand} ${hostArgs.join(" ")}`;
   }
 
-  // parse the APP URI port
+  // parse the API URI port
   let apiPort = (program.apiPort || DEFAULT_CONFIG.apiPort) as number;
 
   // handle the API location config

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -3,7 +3,7 @@ import path from "path";
 import shell from "shelljs";
 import builder from "../../builder";
 import { createRuntimeHost } from "../../runtimeHost";
-import { getBin, isHttpUrl, isPortAvailable, readConfigFile, validateDevServerConfig } from "../../utils";
+import { getBin, isHttpUrl, isPortAvailable, parseUrl, readConfigFile, validateDevServerConfig } from "../../utils";
 import { DEFAULT_CONFIG } from "../config";
 
 export async function start(startContext: string, program: CLIConfig) {
@@ -43,9 +43,6 @@ export async function start(startContext: string, program: CLIConfig) {
     process.exit(0);
   }
 
-  // parse the APP URI port or use default
-  let appPort = (program.appPort || DEFAULT_CONFIG.appPort) as number;
-
   // get the app and api artifact locations
   let [appLocation, appArtifactLocation, apiLocation] = [
     program.appLocation as string,
@@ -63,23 +60,15 @@ export async function start(startContext: string, program: CLIConfig) {
     },
   });
 
-  // set env vars for current command
-  const envVarsObj = {
-    DEBUG: program.verbose ? "*" : "",
-    SWA_CLI_AUTH_PORT: `${program.authPort}`,
-    SWA_CLI_API_PORT: `${program.apiPort}`,
-    SWA_CLI_APP_PORT: `${program.appPort}`,
-    SWA_CLI_APP_LOCATION: configFile?.appLocation as string,
-    SWA_CLI_APP_ARTIFACT_LOCATION: configFile?.appArtifactLocation as string,
-    SWA_CLI_API_LOCATION: configFile?.apiLocation as string,
-    SWA_CLI_HOST: program.host,
-    SWA_CLI_PORT: `${program.port}`,
-  };
+  // parse the APP URI port
+  let appPort = (program.appPort || DEFAULT_CONFIG.appPort) as number;
 
   // handle the APP location config
   let serveStaticContent = undefined;
   if (useAppDevServer) {
     serveStaticContent = `echo 'using app dev server at ${useAppDevServer}'`;
+    const { port } = parseUrl(useAppDevServer);
+    appPort = port;
   } else {
     const { command: hostCommand, args: hostArgs } = createRuntimeHost({
       appPort: appPort,
@@ -91,16 +80,34 @@ export async function start(startContext: string, program: CLIConfig) {
     serveStaticContent = `${hostCommand} ${hostArgs.join(" ")}`;
   }
 
+  // parse the APP URI port
+  let apiPort = (program.apiPort || DEFAULT_CONFIG.apiPort) as number;
+
   // handle the API location config
   let serveApiContent = undefined;
   if (useApiDevServer) {
     serveApiContent = `echo 'using api dev server at ${useApiDevServer}'`;
+    const { port } = parseUrl(useApiDevServer);
+    apiPort = port;
   } else {
     // serve the api if and only if the user provide the --api-location flag
     if (program.apiLocation && configFile?.apiLocation) {
       serveApiContent = `([ -d '${configFile?.apiLocation}' ] && (cd ${configFile?.apiLocation}; func start --cors * --port ${program.apiPort})) || echo 'No API found. Skipping.'`;
     }
   }
+
+  // set env vars for current command
+  const envVarsObj = {
+    DEBUG: program.verbose ? "*" : "",
+    SWA_CLI_AUTH_PORT: `${program.authPort}`,
+    SWA_CLI_API_PORT: `${apiPort}`,
+    SWA_CLI_APP_PORT: `${appPort}`,
+    SWA_CLI_APP_LOCATION: configFile?.appLocation as string,
+    SWA_CLI_APP_ARTIFACT_LOCATION: configFile?.appArtifactLocation as string,
+    SWA_CLI_API_LOCATION: configFile?.apiLocation as string,
+    SWA_CLI_HOST: program.host,
+    SWA_CLI_PORT: `${program.port}`,
+  };
 
   const concurrentlyBin = getBin("concurrently");
 

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -8,7 +8,6 @@ export const DEFAULT_CONFIG: SWACLIConfig = {
   apiPrefix: "api",
   appLocation: `.${path.sep}`,
   appArtifactLocation: `.${path.sep}`,
-  apiLocation: `.${path.sep}api`,
   appBuildCommand: "npm run build --if-present",
   apiBuildCommand: "npm run build --if-present",
 };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -198,16 +198,11 @@ const server = http.createServer(function (req, res) {
       target,
       secure: false,
     });
-
-    proxyApp.on("error", function (err) {
-      console.log("app>>", req.method, target + req.url);
-      res.writeHead(500, {
-        "Content-Type": "text/plain",
-      });
-
-      res.end(err.toString());
-    });
   }
+});
+
+proxyApp.on("error", function (err) {
+  console.error("app>", err.toString());
 });
 
 const port = SWA_CLI_PORT;
@@ -215,8 +210,9 @@ const host = SWA_CLI_HOST;
 const address = `http://${host}:${port}`;
 console.log(`SWA listening on ${address}`);
 server.on("upgrade", function (req, socket, head) {
+  console.log("app>", "Upgrading WebSocket");
   proxyApp.ws(req, socket, head, {
-    target: process.env.SWA_CLI_APP_URI,
+    target: SWA_CLI_APP_URI,
     secure: false,
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -506,7 +506,7 @@ jobs:
         mockFs.restore();
       });
 
-      it("property 'api_location' should be set to 'api' if missing", () => {
+      it("property 'api_location' should be undefined if missing", () => {
         mockFs({
           ".github/workflows/azure-static-web-apps.yml": `
 jobs:
@@ -520,7 +520,7 @@ jobs:
         });
 
         expect(readConfigFile()).toBeTruthy();
-        expect(readConfigFile()?.apiLocation).toBe(path.normalize(process.cwd() + "/api"));
+        expect(readConfigFile()?.apiLocation).toBeUndefined();
 
         mockFs.restore();
       });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -385,7 +385,7 @@ export function getBin(binary: string) {
     return path.isAbsolute(binary) ? binary : path.resolve(binary);
   }
 
-  const binDirOutput = spawnSync(isWindows() ? "npm.cmd" : "npm", ["bin"], { cwd: process.cwd() });
+  const binDirOutput = spawnSync(isWindows() ? "npm.cmd" : "npm", ["bin"], { cwd: __dirname });
   const binDirErr = binDirOutput.stderr.toString();
   if (binDirErr) {
     console.error({ binDirErr });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -205,7 +205,9 @@ export const readConfigFile = ({ userConfig }: { userConfig?: Partial<GithubActi
   // - app_artifact_location
 
   app_location = path.normalize(path.join(process.cwd(), app_location));
-  api_location = path.normalize(path.join(process.cwd(), api_location || path.sep));
+  if (typeof api_location !== "undefined") {
+    api_location = path.normalize(path.join(process.cwd(), api_location || path.sep));
+  }
   app_artifact_location = path.normalize(app_artifact_location);
 
   const detectedRuntimeType = detectRuntime(app_location);


### PR DESCRIPTION
* Fix `concurrently` resolving to the wrong path (fixes #73)
* Don't default api folder to `api` (fixes #74)
* Use the correct port when running CLI with app or api URIs (fixes #75)
* Fix WebSocket forwarding to dev server (fixes #76)