### PR TITLE
build: add npm prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "prebuild": "rm -fr dist",
     "postbuild": "npm run copy-assets",
     "watch": "tsc --watch",
-    "copy-assets": "node ./scripts/copy-assets.js"
+    "copy-assets": "node ./scripts/copy-assets.js",
+    "prepare": "npm run build"
   },
   "bin": {
     "swa": "dist/cli/index.js",


### PR DESCRIPTION
Add `prepare` script to automatically build the project on local install and linking.

It allows running a dev version and working on the project more easily:
- you can npm install directly from the github repo without errors
- you can clone the project and run `npm link` immediately without errors

As a bonus, this also builds the project before packing or publishing the project, avoiding the possibility of outdated builds when publishing.