### PR TITLE
fix: update CLI bin file permissions

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const [, , ...args] = process.argv;
+const args = process.argv.slice(2);
 process.title = ["swa", ...args].join(" ");
 
 import program from "commander";


### PR DESCRIPTION
Add the executable bit to the CLI "bin" to avoid permission denied errors when running SWA (ie`zsh: permission denied: swa`).
Note that the change doesn't appear on GitHub.

I had to made a change to the file so the commit gets accepted by the linter rules 😉 