### PR TITLE
feat: Support serving web and api over https locally

### DIFF
--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -94,6 +94,9 @@ export async function start(startContext: string, options: SWACLIConfig) {
     SWA_CLI_HOST: options.host,
     SWA_CLI_PORT: `${options.port}`,
     SWA_WORKFLOW_FILES: userConfig?.files?.join(","),
+    SWA_CLI_APP_SSL: `${options.ssl}`,
+    SWA_CLI_APP_SSL_CERT: options.sslCert,
+    SWA_CLI_APP_SSL_KEY: options.sslKey,
   };
 
   if (options.verbose?.includes("silly")) {

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -84,20 +84,9 @@ export async function start(startContext: string, options: SWACLIConfig) {
     }
   }
 
-  let sslCertLocation = options.sslCert;
-  let sslKeyLocation = options.sslKey;
-
   if (options.ssl) {
     if (options.sslCert === undefined || options.sslKey === undefined) {
-      const defaultSslCertLocation = path.join("ssl", "localhost.crt");
-      const defaultSslKeyLocation = path.join("ssl", "localhost.key");
-      const isSslCertExistsOnDefaultLocation = fs.existsSync(defaultSslCertLocation);
-      const isSslKeyExistsOnDefaultLocation = fs.existsSync(defaultSslKeyLocation);
-      if (isSslCertExistsOnDefaultLocation === false || isSslKeyExistsOnDefaultLocation === false) {
-        logger.error(`SSL Key or SSL Cert are required when using HTTPS`, true);
-      }
-      sslCertLocation = defaultSslCertLocation;
-      sslKeyLocation = defaultSslKeyLocation;
+      logger.error(`SSL Key or SSL Cert are required when using HTTPS`, true);
     }
   }
 
@@ -112,8 +101,8 @@ export async function start(startContext: string, options: SWACLIConfig) {
     SWA_CLI_PORT: `${options.port}`,
     SWA_WORKFLOW_FILES: userConfig?.files?.join(","),
     SWA_CLI_APP_SSL: `${options.ssl}`,
-    SWA_CLI_APP_SSL_CERT: sslCertLocation,
-    SWA_CLI_APP_SSL_KEY: sslKeyLocation,
+    SWA_CLI_APP_SSL_CERT: options.sslCert,
+    SWA_CLI_APP_SSL_KEY: options.sslKey,
   };
 
   if (options.verbose?.includes("silly")) {

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -84,6 +84,23 @@ export async function start(startContext: string, options: SWACLIConfig) {
     }
   }
 
+  let sslCertLocation = options.sslCert;
+  let sslKeyLocation = options.sslKey;
+
+  if (options.ssl) {
+    if (options.sslCert === undefined || options.sslKey === undefined) {
+      const defaultSslCertLocation = path.join("ssl", "localhost.crt");
+      const defaultSslKeyLocation = path.join("ssl", "localhost.key");
+      const isSslCertExistsOnDefaultLocation = fs.existsSync(defaultSslCertLocation);
+      const isSslKeyExistsOnDefaultLocation = fs.existsSync(defaultSslKeyLocation);
+      if (isSslCertExistsOnDefaultLocation === false || isSslKeyExistsOnDefaultLocation === false) {
+        logger.error(`SSL Key or SSL Cert are required when using HTTPS`, true);
+      }
+      sslCertLocation = defaultSslCertLocation;
+      sslKeyLocation = defaultSslKeyLocation;
+    }
+  }
+
   // set env vars for current command
   const envVarsObj = {
     SWA_CLI_DEBUG: options.verbose,
@@ -95,8 +112,8 @@ export async function start(startContext: string, options: SWACLIConfig) {
     SWA_CLI_PORT: `${options.port}`,
     SWA_WORKFLOW_FILES: userConfig?.files?.join(","),
     SWA_CLI_APP_SSL: `${options.ssl}`,
-    SWA_CLI_APP_SSL_CERT: options.sslCert,
-    SWA_CLI_APP_SSL_KEY: options.sslKey,
+    SWA_CLI_APP_SSL_CERT: sslCertLocation,
+    SWA_CLI_APP_SSL_KEY: sslKeyLocation,
   };
 
   if (options.verbose?.includes("silly")) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -35,8 +35,8 @@ import { start } from "./commands/start";
     .option<number>("--port <port>", "set the cli port", parsePort, DEFAULT_CONFIG.port)
     .option("--build", "build the app and API before starting the emulator", false)
     .option("--ssl", "serving the app and API over HTTPS", DEFAULT_CONFIG.ssl)
-    .option("--ssl-cert <sslCertLocation>", "set the location where ssl certificate file is used for serving", DEFAULT_CONFIG.sslCert)
-    .option("--ssl-key <sslKeyLocation>", "set the location where ssl key file is used for serving", DEFAULT_CONFIG.sslKey)
+    .option("--ssl-cert <sslCertLocation>", "SSL certificate to use for serving HTTPS", DEFAULT_CONFIG.sslCert)
+    .option("--ssl-key <sslKeyLocation>", "SSL key to use for serving HTTPS", DEFAULT_CONFIG.sslKey)
     .action(async (context: string = `.${path.sep}`, options: any) => {
       options = {
         ...options,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -34,6 +34,9 @@ import { start } from "./commands/start";
     .option("--host <host>", "set the cli host address", DEFAULT_CONFIG.host)
     .option<number>("--port <port>", "set the cli port", parsePort, DEFAULT_CONFIG.port)
     .option("--build", "build the app and API before starting the emulator", false)
+    .option("--ssl", "serving the app and API over HTTPS", DEFAULT_CONFIG.ssl)
+    .option("--ssl-cert <sslCertLocation>", "set the location where ssl certificate file is used for serving", DEFAULT_CONFIG.sslCert)
+    .option("--ssl-key <sslKeyLocation>", "set the location where ssl key file is used for serving", DEFAULT_CONFIG.sslKey)
     .action(async (context: string = `.${path.sep}`, options: any) => {
       options = {
         ...options,

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ export const DEFAULT_CONFIG: SWACLIConfig = {
   host: "0.0.0.0",
   apiPort: 7071,
   apiPrefix: "api",
-  useHttps: "false",
+  useHttps: false,
   appLocation: `.${path.sep}`,
   appArtifactLocation: `.${path.sep}`,
   appBuildCommand: "npm run build --if-present",

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ export const DEFAULT_CONFIG: SWACLIConfig = {
   host: "0.0.0.0",
   apiPort: 7071,
   apiPrefix: "api",
-  useHttps: false,
+  ssl: false,
   appLocation: `.${path.sep}`,
   appArtifactLocation: `.${path.sep}`,
   appBuildCommand: "npm run build --if-present",

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ export const DEFAULT_CONFIG: SWACLIConfig = {
   host: "0.0.0.0",
   apiPort: 7071,
   apiPrefix: "api",
+  useHttps: "false",
   appLocation: `.${path.sep}`,
   appArtifactLocation: `.${path.sep}`,
   appBuildCommand: "npm run build --if-present",

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,8 @@ export const DEFAULT_CONFIG: SWACLIConfig = {
   ssl: false,
   appLocation: `.${path.sep}`,
   appArtifactLocation: `.${path.sep}`,
+  sslCert: undefined,
+  sslKey: undefined,
   appBuildCommand: "npm run build --if-present",
   apiBuildCommand: "npm run build --if-present",
   swaConfigFilename: "staticwebapp.config.json",

--- a/src/core/utils.test.ts
+++ b/src/core/utils.test.ts
@@ -770,5 +770,10 @@ jobs:
       expect(address("127.0.0.1", "4200")).toBe("http://127.0.0.1:4200");
       expect(address("[::1]", "4200")).toBe("http://[::1]:4200");
     });
+
+    it("should accept protocol", () => {
+      expect(address("127.0.0.1", "4200", "http")).toBe("http://127.0.0.1:4200");
+      expect(address("127.0.0.1", "4200", "https")).toBe("https://127.0.0.1:4200");
+    });
   });
 });

--- a/src/core/utils.test.ts
+++ b/src/core/utils.test.ts
@@ -771,7 +771,7 @@ jobs:
       expect(address("[::1]", "4200")).toBe("http://[::1]:4200");
     });
 
-    it("should accept protocol", () => {
+    it("should accept protocol both HTTP and HTTPS protocols", () => {
       expect(address("127.0.0.1", "4200", "http")).toBe("http://127.0.0.1:4200");
       expect(address("127.0.0.1", "4200", "https")).toBe("https://127.0.0.1:4200");
     });

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -476,8 +476,7 @@ export async function findSWAConfigFile(folder: string) {
   return null;
 }
 
-export const address = (host: string, port: number | string | undefined) => {
-  const protocol = `http`;
+export const address = (host: string, port: number | string | undefined, protocol = `http`) => {
   if (!host) {
     throw new Error(`Host value is not set`);
   }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -19,7 +19,7 @@ const SWA_CLI_PORT = parseInt((process.env.SWA_CLI_PORT || DEFAULT_CONFIG.port) 
 const SWA_CLI_API_URI = address(SWA_CLI_HOST, process.env.SWA_CLI_API_PORT);
 const SWA_CLI_APP_LOCATION = (process.env.SWA_CLI_APP_LOCATION || DEFAULT_CONFIG.appLocation) as string;
 const SWA_CLI_APP_ARTIFACT_LOCATION = (process.env.SWA_CLI_APP_ARTIFACT_LOCATION || DEFAULT_CONFIG.appArtifactLocation) as string;
-const SWA_CLI_APP_USE_HTTPS = (process.env.SWA_CLI_APP_USE_HTTPS || DEFAULT_CONFIG.useHttps) === "true";
+const SWA_CLI_APP_USE_HTTPS = process.env.SWA_CLI_APP_USE_HTTPS === "true" || DEFAULT_CONFIG.useHttps === true;
 const SWA_CLI_APP_SSL_KEY = process.env.SWA_CLI_APP_SSL_KEY as string;
 const SWA_CLI_APP_SSL_CERT = process.env.SWA_CLI_APP_SSL_CERT as string;
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -39,7 +39,7 @@ if (SWA_WORKFLOW_CONFIG_FILE) {
 }
 
 if (SWA_CLI_APP_USE_HTTPS && (SWA_CLI_APP_SSL_KEY === undefined || SWA_CLI_APP_SSL_CERT === undefined)) {
-  logger.error(`If use HTTPS, must be set SWA_CLI_APP_SSL_KEY and SWA_CLI_APP_SSL_CERT`, true);
+  logger.error(`SSL Key or SSL Cert are required when using HTTPS`, true);
 }
 
 const httpsServerOptions: Pick<https.ServerOptions, "cert" | "key"> | null = SWA_CLI_APP_USE_HTTPS

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -19,11 +19,11 @@ const SWA_CLI_PORT = parseInt((process.env.SWA_CLI_PORT || DEFAULT_CONFIG.port) 
 const SWA_CLI_API_URI = address(SWA_CLI_HOST, process.env.SWA_CLI_API_PORT);
 const SWA_CLI_APP_LOCATION = (process.env.SWA_CLI_APP_LOCATION || DEFAULT_CONFIG.appLocation) as string;
 const SWA_CLI_APP_ARTIFACT_LOCATION = (process.env.SWA_CLI_APP_ARTIFACT_LOCATION || DEFAULT_CONFIG.appArtifactLocation) as string;
-const SWA_CLI_APP_USE_HTTPS = process.env.SWA_CLI_APP_USE_HTTPS === "true" || DEFAULT_CONFIG.useHttps === true;
+const SWA_CLI_APP_SSL = process.env.SWA_CLI_APP_SSL === "true" || DEFAULT_CONFIG.ssl === true;
 const SWA_CLI_APP_SSL_KEY = process.env.SWA_CLI_APP_SSL_KEY as string;
 const SWA_CLI_APP_SSL_CERT = process.env.SWA_CLI_APP_SSL_CERT as string;
 
-const PROTOCOL = SWA_CLI_APP_USE_HTTPS ? `https` : `http`;
+const PROTOCOL = SWA_CLI_APP_SSL ? `https` : `http`;
 
 const proxyApi = httpProxy.createProxyServer({ autoRewrite: true });
 const proxyApp = httpProxy.createProxyServer({ autoRewrite: true });
@@ -38,11 +38,11 @@ if (SWA_WORKFLOW_CONFIG_FILE) {
   logger.info(`\nFound workflow file:\n    ${chalk.green(SWA_WORKFLOW_CONFIG_FILE)}`);
 }
 
-if (SWA_CLI_APP_USE_HTTPS && (SWA_CLI_APP_SSL_KEY === undefined || SWA_CLI_APP_SSL_CERT === undefined)) {
+if (SWA_CLI_APP_SSL && (SWA_CLI_APP_SSL_KEY === undefined || SWA_CLI_APP_SSL_CERT === undefined)) {
   logger.error(`SSL Key or SSL Cert are required when using HTTPS`, true);
 }
 
-const httpsServerOptions: Pick<https.ServerOptions, "cert" | "key"> | null = SWA_CLI_APP_USE_HTTPS
+const httpsServerOptions: Pick<https.ServerOptions, "cert" | "key"> | null = SWA_CLI_APP_SSL
   ? {
       cert: fs.readFileSync(SWA_CLI_APP_SSL_CERT, "utf8"),
       key: fs.readFileSync(SWA_CLI_APP_SSL_KEY, "utf8"),
@@ -292,7 +292,7 @@ const requestHandler = (userConfig: SWAConfigFile | null) =>
     userConfig = await handleUserConfig(SWA_CLI_APP_LOCATION);
   }
   const createServer = () => {
-    if (SWA_CLI_APP_USE_HTTPS && httpsServerOptions !== null) {
+    if (SWA_CLI_APP_SSL && httpsServerOptions !== null) {
       return https.createServer(httpsServerOptions, requestHandler(userConfig));
     }
     return http.createServer(requestHandler(userConfig));

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -38,10 +38,6 @@ if (SWA_WORKFLOW_CONFIG_FILE) {
   logger.info(`\nFound workflow file:\n    ${chalk.green(SWA_WORKFLOW_CONFIG_FILE)}`);
 }
 
-if (SWA_CLI_APP_SSL && (SWA_CLI_APP_SSL_KEY === undefined || SWA_CLI_APP_SSL_CERT === undefined)) {
-  logger.error(`SSL Key or SSL Cert are required when using HTTPS`, true);
-}
-
 const httpsServerOptions: Pick<https.ServerOptions, "cert" | "key"> | null = SWA_CLI_APP_SSL
   ? {
       cert: fs.readFileSync(SWA_CLI_APP_SSL_CERT, "utf8"),

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -61,6 +61,8 @@ declare type SWACLIConfig = GithubActionWorkflow & {
   apiPort?: number;
   ssl?: boolean;
   apiPrefix?: "api";
+  sslCert?: string;
+  sslKey?: string;
   swaConfigFilename?: "staticwebapp.config.json";
   swaConfigFilenameLegacy?: "routes.json";
   app?: string;

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -56,6 +56,7 @@ declare type SWACLIConfig = GithubActionWorkflow & {
   port?: number;
   host?: string;
   apiPort?: number;
+  useHttps?: "true" | "false" | string;
   apiPrefix?: "api";
   swaConfigFilename?: "staticwebapp.config.json";
   swaConfigFilenameLegacy?: "routes.json";

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -8,6 +8,9 @@ declare global {
       SWA_CLI_HOST: string;
       SWA_CLI_PORT: string;
       SWA_WORKFLOW_FILE: string;
+      SWA_CLI_APP_SSL: boolean;
+      SWA_CLI_APP_SSL_KEY: string;
+      SWA_CLI_APP_SSL_CERT: string;
     }
   }
 }

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -56,7 +56,7 @@ declare type SWACLIConfig = GithubActionWorkflow & {
   port?: number;
   host?: string;
   apiPort?: number;
-  useHttps?: boolean;
+  ssl?: boolean;
   apiPrefix?: "api";
   swaConfigFilename?: "staticwebapp.config.json";
   swaConfigFilenameLegacy?: "routes.json";

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -56,7 +56,7 @@ declare type SWACLIConfig = GithubActionWorkflow & {
   port?: number;
   host?: string;
   apiPort?: number;
-  useHttps?: "true" | "false" | string;
+  useHttps?: boolean;
   apiPrefix?: "api";
   swaConfigFilename?: "staticwebapp.config.json";
   swaConfigFilenameLegacy?: "routes.json";


### PR DESCRIPTION
ref: https://github.com/Azure/static-web-apps-cli/issues/4

Some Web API requires contents served over https (for example: Navigator.mediaDevices.getUserMedia).
Since it can be used if it is provided from a specific location such as localhost and file protocol, we can use by using localhost over http, which is currently available.
So it's a low priority because there are alternatives ways, but I guess this feature will bring it closer to production.

I tried the following command

```
$ pwd
~/Projects/github.com/yamachu/static-web-apps-cli
$ SWA_CLI_APP_USE_HTTPS=true SWA_CLI_APP_SSL_KEY="./scripts/localhost.key" SWA_CLI_APP_SSL_CERT="./scripts/localhost.crt" npm start start http://localhost:8000
```

