### PR TITLE
fix: preserve auth provider and post login url on rewrites

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ jobs:
   e2e:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         node-version: [12.x, 14.x]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ jobs:
   e2e:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
         node-version: [12.x, 14.x]
 
     runs-on: ${{ matrix.os }}

--- a/cypress.json
+++ b/cypress.json
@@ -1,1 +1,4 @@
-{}
+{
+  "viewportWidth": 1300,
+  "viewportHeight": 900
+}

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,4 @@
 {
   "viewportWidth": 1300,
-  "viewportHeight": 900,
-  "defaultCommandTimeout": 60000
+  "viewportHeight": 900
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
   "viewportWidth": 1300,
-  "viewportHeight": 900
+  "viewportHeight": 900,
+  "defaultCommandTimeout": 60000
 }

--- a/cypress/fixtures/static/staticwebapp.config.json
+++ b/cypress/fixtures/static/staticwebapp.config.json
@@ -45,6 +45,14 @@
     {
       "route": "/rewrite-to-function",
       "rewrite": "/api/headers"
+    },
+    {
+      "route": "/login-github",
+      "rewrite": "/.auth/login/github"
+    },
+    {
+      "route": "/logout",
+      "rewrite": "/.auth/logout"
     }
   ],
   "navigationFallback": {

--- a/cypress/integration/authentication.js
+++ b/cypress/integration/authentication.js
@@ -1,5 +1,7 @@
 /// <reference types="cypress" />
 
+const PROVIDERS = ["github", "twitter", "facebook", "google", "aad"];
+
 context("/.auth/me", () => {
   let clientPrincipal;
 
@@ -48,35 +50,174 @@ context("/.auth/me", () => {
   });
 });
 
-context("/.auth/login/github", () => {
-  let clientPrincipal;
+context(`/.auth/login/<provider>`, () => {
+  for (let index = 0; index < PROVIDERS.length; index++) {
+    const provider = PROVIDERS[index];
+    describe(`when using provider: ${provider}`, () => {
+      it(`provider should be ${provider}`, () => {
+        cy.visit(`http://0.0.0.0:1234/.auth/login/${provider}`);
+        cy.get("#identityProvider").should("be.disabled");
+        cy.get("#identityProvider").should("have.value", provider);
+      });
+      it("username should be empty", () => {
+        cy.visit(`http://0.0.0.0:1234/.auth/login/${provider}`);
+        cy.get("#userDetails").should("be.empty");
+      });
+      it("userId should be empty", () => {
+        cy.visit(`http://0.0.0.0:1234/.auth/login/${provider}`);
+        cy.get("#userId").should("be.empty");
+      });
+      it("userRoles should contains authenticated and anonymous roles", () => {
+        cy.visit(`http://0.0.0.0:1234/.auth/login/${provider}`);
+        cy.get("#userRoles").should("have.value", "anonymous\nauthenticated");
+      });
+    });
+  }
+});
 
+context("/.auth/logout", () => {
   beforeEach(() => {
-    cy.visit("http://0.0.0.0:1234/.auth/login/github");
-
-    clientPrincipal = {
-      identityProvider: "facebook",
-      userId: "d75b260a64504067bfc5b2905e3b8182",
-      userDetails: "user@example.com",
-      userRoles: ["anonymous", "authenticated"],
-    };
-
-    cy.clearCookie("StaticWebAppsAuthCookie");
+    cy.visit("http://0.0.0.0:1234");
   });
 
-  describe("when using GitHub provider", () => {
+  describe("when using accessing /.auth/logout", () => {
+    it("should redirect to / with code=302", () => {
+      cy.request({
+        url: "/.auth/logout",
+        followRedirect: false,
+      }).as("response");
+
+      cy.get("@response")
+        .its("headers")
+        .then((headers) => {
+          expect(headers).to.deep.include({
+            status: "302",
+            location: "http://0.0.0.0:1234/",
+            "set-cookie": ["StaticWebAppsAuthCookie=deleted; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT"],
+          });
+        });
+    });
+  });
+});
+
+context("custom routes for login/logout", () => {
+  describe("when using custom route /login-github", () => {
+    beforeEach(() => {
+      cy.visit("http://0.0.0.0:1234/login-github");
+    });
     it("provider should be 'github'", () => {
       cy.get("#identityProvider").should("be.disabled");
       cy.get("#identityProvider").should("have.value", "github");
     });
-    it("username should be empty", () => {
-      cy.get("#userDetails").should("be.empty");
+
+    it("should have meta tag", () => {
+      cy.get("meta[name='swa:originalPath']").should("have.attr", "content", "/.auth/login/github");
     });
-    it("userId should be empty", () => {
-      cy.get("#userId").should("be.empty");
+  });
+
+  describe("when using custom /logout route", () => {
+    it("should redirect to / with code=302", () => {
+      cy.request({
+        url: "/logout",
+        followRedirect: false,
+      }).as("response");
+
+      cy.get("@response")
+        .its("headers")
+        .then((headers) => {
+          expect(headers).to.deep.include({
+            status: "302",
+            location: "http://0.0.0.0:1234/",
+            "set-cookie": ["StaticWebAppsAuthCookie=deleted; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT"],
+          });
+        });
     });
-    it("userRoles should contains authenticated and anonymous roles", () => {
-      cy.get("#userRoles").should("have.value", "anonymous\nauthenticated");
+  });
+});
+
+context("checking localStorage", () => {
+  beforeEach(() => {
+    cy.clearLocalStorage();
+  });
+  describe("caching auth info in localStorage", () => {
+    for (let index = 0; index < PROVIDERS.length; index++) {
+      const provider = PROVIDERS[index];
+      it(`should cache auth: ${provider}`, () => {
+        cy.visit(`http://0.0.0.0:1234/.auth/login/${provider}`);
+        cy.get("#userDetails")
+          .type(`foobar-${provider}`)
+          .trigger("keyup")
+          .should(() => {
+            const authInfo = localStorage.getItem(`auth@${provider}`);
+            expect(authInfo).not.to.be.null;
+
+            const json = JSON.parse(authInfo);
+            expect(json.userId.length).to.eq(32);
+            expect(json.identityProvider).to.eq(provider);
+            expect(json.userDetails).to.eq(`foobar-${provider}`);
+            expect(json.userRoles).to.deep.eq(["anonymous", "authenticated"]);
+          });
+      });
+    }
+  });
+});
+
+context("UI buttons", () => {
+  describe("Login button", () => {
+    it("should not submit if missing userId ", () => {
+      cy.visit(`http://0.0.0.0:1234/.auth/login/github`);
+      cy.get("#userId").clear();
+      cy.get("#submit").click();
+
+      cy.get("#userId:invalid").should("exist");
+    });
+
+    it("should not submit if missing userDetails ", () => {
+      cy.visit(`http://0.0.0.0:1234/.auth/login/github`);
+      cy.get("#userDetails").clear();
+      cy.get("#submit").click();
+
+      cy.get("#userDetails:invalid").should("exist");
+    });
+
+    it("should submit and redirect to /", () => {
+      cy.visit(`http://0.0.0.0:1234/.auth/login/github`);
+      cy.get("#userDetails").type("foo");
+      cy.get("#submit")
+        .click()
+        .then(() => {
+          cy.url().should("eq", "http://0.0.0.0:1234/");
+        });
+    });
+
+    it("should submit and redirect to /home", () => {
+      cy.visit(`http://0.0.0.0:1234/.auth/login/github?post_login_redirect_uri=/home`);
+      cy.get("#userDetails").type("foo");
+      cy.get("#submit")
+        .click()
+        .then(() => {
+          cy.url().should("eq", "http://0.0.0.0:1234/home");
+        });
+    });
+  });
+
+  describe("Clear button", () => {
+    it("should reset form", () => {
+      cy.visit(`http://0.0.0.0:1234/.auth/login/github`);
+      cy.get("#clear")
+        .click()
+        .then(() => {
+          cy.get("#identityProvider").should("have.value", "github");
+          cy.get("#userDetails").should("have.value", "");
+          cy.get("#userRoles").should((element) => {
+            expect(element.val()).to.eq("anonymous\nauthenticated");
+          });
+          cy.get("#userId").should((element) => {
+            expect(element.val().length).to.eq(32);
+          });
+
+          expect(localStorage.getItem("auth@github")).not.to.be.null;
+        });
     });
   });
 });

--- a/cypress/integration/route-rules-engine.js
+++ b/cypress/integration/route-rules-engine.js
@@ -6,13 +6,15 @@ context("route rules engine", () => {
   });
 
   it("root returns /index.html", async () => {
-    cy.request("/");
-    cy.title().should("eq", "/index.html");
+    cy.request("/").then(() => {
+      cy.title().should("eq", "/index.html");
+    });
   });
 
   it("/index.html returns /index.html", async () => {
-    cy.request("/index.html");
-    cy.title().should("eq", "/index.html");
+    cy.request("/index.html").then(() => {
+      cy.title().should("eq", "/index.html");
+    });
   });
 
   it("folder returns folder/index.html", async () => {
@@ -22,167 +24,141 @@ context("route rules engine", () => {
   });
 
   it("rewrite to file returns correct content", async () => {
-    cy.request("/rewrite_index2");
-    cy.title().should("eq", "/index2.html");
+    cy.request("/rewrite_index2").then(() => {
+      cy.title().should("eq", "/index2.html");
+    });
   });
 
   it("rewrite to function returns function response", async () => {
-    cy.request("/rewrite-to-function").as("response");
-    cy.get("@response").should((response) => {
+    cy.request("/rewrite-to-function").then((response) => {
       expect(response).to.have.property("x-swa-custom");
       expect(response["x-swa-custom"]).to.be("/api/headers");
     });
   });
 
   it("content response contains global headers", async () => {
-    cy.request({
-      url: "/",
-      redirect: "manual",
-      failOnStatusCode: false,
-    }).as("response");
-
-    cy.get("@response").should((response) => {
+    cy.request("/").then((response) => {
       expect(response.headers.get("a")).to.be("b");
     });
   });
 
   it("route headers override global headers", async () => {
-    cy.request({
-      url: "/rewrite_index2",
-      redirect: "manual",
-      failOnStatusCode: false,
-    }).as("response");
-
-    cy.get("@response").should((response) => {
+    cy.request("/rewrite_index2").then((response) => {
       expect(response.headers.get("a")).to.be("c");
     });
   });
 
   it("default redirect returns 302 with correct location", async () => {
-    cy.request({
-      url: "/redirect/foo",
-      redirect: "manual",
-      failOnStatusCode: false,
-    }).as("response");
+    cy.request("/redirect/foo").as("response");
 
-    cy.get("@response").should((response) => {
-      expect(response.status).to.be(302);
-      expect(response.headers.get("location").replace(new RegExp(`^${baseUrl.replace(".", "\\.")}`), "")).to.be("/index2.html");
-    });
+    cy.get("@response")
+      .its("headers")
+      .then((headers) => {
+        expect(headers).to.deep.include({
+          status: "302",
+          location: "http://0.0.0.0:1234/index2.html",
+        });
+      });
   });
 
   it("redirect with statusCode 302 returns 302 with correct location", async () => {
-    cy.request({
-      url: "/redirect/302",
-      redirect: "manual",
-      failOnStatusCode: false,
-    }).as("response");
+    cy.request("/redirect/302").as("response");
 
-    cy.get("@response").should((response) => {
-      expect(response.status).to.be(302);
-      expect(response.headers.get("location").replace(new RegExp(`^${baseUrl.replace(".", "\\.")}`), "")).to.be("/index2.html");
-    });
+    cy.get("@response")
+      .its("headers")
+      .then((headers) => {
+        expect(headers).to.deep.include({
+          status: "302",
+          location: "http://0.0.0.0:1234/index2.html",
+        });
+      });
   });
 
   it("redirect with statusCode 301 returns 301 with correct location", async () => {
-    cy.request({
-      url: "/redirect/301",
-      redirect: "manual",
-      failOnStatusCode: false,
-    }).as("response");
+    cy.request("/redirect/301").as("response");
 
-    cy.get("@response").should((response) => {
-      expect(response.status).to.be(301);
-      expect(response.headers.get("location").replace(new RegExp(`^${baseUrl.replace(".", "\\.")}`), "")).to.be("/index2.html");
-    });
+    cy.get("@response")
+      .its("headers")
+      .then((headers) => {
+        expect(headers).to.deep.include({
+          status: "302",
+          location: "http://0.0.0.0:1234/index2.html",
+        });
+      });
   });
 
   it("setting mimetype of unknown file type returns correct mime type", async () => {
-    cy.request({
-      url: "/test.swaconfig",
-      redirect: "manual",
-      failOnStatusCode: false,
-    }).as("response");
-
-    cy.get("@response").should((response) => {
+    cy.request("/test.swaconfig").then((response) => {
       expect(response.status).to.be(200);
       expect(response.headers.get("content-type")).to.be("application/json");
     });
   });
 
   it("navigation fallback returns /index.html", async () => {
-    cy.request("/does_not_exist.html").as("response");
-
-    cy.get("@response").should((response) => {
+    cy.request("/does_not_exist.html").then((response) => {
       expect(response.status).to.be(200);
       cy.title().should("eq", "/index.html");
     });
   });
 
   it("navigation fallback that's excluded returns 404", async () => {
-    cy.request({
-      url: "/does_not_exist.txt",
-      redirect: "manual",
-      failOnStatusCode: false,
-    }).as("response");
-
-    cy.get("@response").should((response) => {
+    cy.request("/does_not_exist.txt").then((response) => {
       expect(response.status).to.be(404);
     });
   });
 
   it("/*.foo matches extension", async () => {
-    cy.request({
-      url: "/thing.foo",
-      redirect: "manual",
-      failOnStatusCode: false,
-    }).as("response");
+    cy.request("/thing.foo").as("response");
 
-    cy.get("@response").should((response) => {
-      expect(response.headers.get("location").replace(new RegExp(`^${baseUrl.replace(".", "\\.")}`), "")).to.be("/foo.html");
-    });
+    cy.get("@response")
+      .its("headers")
+      .then((headers) => {
+        expect(headers).to.deep.include({
+          status: "302",
+          location: "http://0.0.0.0:1234/foo.html",
+        });
+      });
   });
 
   it("/*.{jpg} matches extension", async () => {
-    cy.request({
-      url: "/thing.jpg",
-      redirect: "manual",
-      failOnStatusCode: false,
-    }).as("response");
+    cy.request("/thing.jpg").as("response");
 
-    cy.get("@response").should((response) => {
-      expect(response.headers.get("location").replace(new RegExp(`^${baseUrl.replace(".", "\\.")}`), "")).to.be("/jpg.html");
-    });
+    cy.get("@response")
+      .its("headers")
+      .then((headers) => {
+        expect(headers).to.deep.include({
+          status: "302",
+          location: "http://0.0.0.0:1234/jpg.html",
+        });
+      });
   });
 
   it("/*.{png,gif} matches multiple extensions", async () => {
-    cy.request({
-      url: "/thing.png",
-      redirect: "manual",
-      failOnStatusCode: false,
-    }).as("response1");
+    cy.request("/thing.png").as("response1");
 
-    cy.get("@response1").should((response) => {
-      expect(response.headers.get("location").replace(new RegExp(`^${baseUrl.replace(".", "\\.")}`), "")).to.be("/png_gif.html");
+    cy.get("@response1")
+    .its("headers")
+    .then((headers) => {
+      expect(headers).to.deep.include({
+        status: "302",
+        location: "http://0.0.0.0:1234/png_gif.html",
+      });
     });
 
-    cy.request({
-      url: "/thing.gif",
-      redirect: "manual",
-      failOnStatusCode: false,
-    }).as("response2");
+    cy.request("/thing.gif").as("response2");
 
-    cy.get("@response2").should((response) => {
-      expect(response.headers.get("location").replace(new RegExp(`^${baseUrl.replace(".", "\\.")}`), "")).to.be("/png_gif.html");
+    cy.get("@response2")
+    .its("headers")
+    .then((headers) => {
+      expect(headers).to.deep.include({
+        status: "302",
+        location: "http://0.0.0.0:1234/png_gif.html",
+      });
     });
   });
 
   it("redirect can redirect to external URL", async () => {
-    cy.request({
-      url: "/something.google",
-      redirect: "manual",
-      failOnStatusCode: false,
-    }).then((response) => {
+    cy.request("/something.google").then((response) => {
       expect(response.status).to.be(302);
       expect(response.headers.get("location")).to.be("https://www.google.com/");
     });

--- a/cypress/integration/route-rules-engine.js
+++ b/cypress/integration/route-rules-engine.js
@@ -16,8 +16,9 @@ context("route rules engine", () => {
   });
 
   it("folder returns folder/index.html", async () => {
-    cy.request("/folder/");
-    cy.title().should("eq", "/folder/index.html");
+    cy.request("/folder/").then(() => {
+      cy.title().should("eq", "/folder/index.html");
+    });
   });
 
   it("rewrite to file returns correct content", async () => {
@@ -37,7 +38,7 @@ context("route rules engine", () => {
     cy.request({
       url: "/",
       redirect: "manual",
-      failOnStatusCode: false
+      failOnStatusCode: false,
     }).as("response");
 
     cy.get("@response").should((response) => {
@@ -49,7 +50,7 @@ context("route rules engine", () => {
     cy.request({
       url: "/rewrite_index2",
       redirect: "manual",
-      failOnStatusCode: false
+      failOnStatusCode: false,
     }).as("response");
 
     cy.get("@response").should((response) => {
@@ -61,7 +62,7 @@ context("route rules engine", () => {
     cy.request({
       url: "/redirect/foo",
       redirect: "manual",
-      failOnStatusCode: false
+      failOnStatusCode: false,
     }).as("response");
 
     cy.get("@response").should((response) => {
@@ -74,7 +75,7 @@ context("route rules engine", () => {
     cy.request({
       url: "/redirect/302",
       redirect: "manual",
-      failOnStatusCode: false
+      failOnStatusCode: false,
     }).as("response");
 
     cy.get("@response").should((response) => {
@@ -87,7 +88,7 @@ context("route rules engine", () => {
     cy.request({
       url: "/redirect/301",
       redirect: "manual",
-      failOnStatusCode: false
+      failOnStatusCode: false,
     }).as("response");
 
     cy.get("@response").should((response) => {
@@ -100,7 +101,7 @@ context("route rules engine", () => {
     cy.request({
       url: "/test.swaconfig",
       redirect: "manual",
-      failOnStatusCode: false
+      failOnStatusCode: false,
     }).as("response");
 
     cy.get("@response").should((response) => {
@@ -122,7 +123,7 @@ context("route rules engine", () => {
     cy.request({
       url: "/does_not_exist.txt",
       redirect: "manual",
-      failOnStatusCode: false
+      failOnStatusCode: false,
     }).as("response");
 
     cy.get("@response").should((response) => {
@@ -134,7 +135,7 @@ context("route rules engine", () => {
     cy.request({
       url: "/thing.foo",
       redirect: "manual",
-      failOnStatusCode: false
+      failOnStatusCode: false,
     }).as("response");
 
     cy.get("@response").should((response) => {
@@ -146,7 +147,7 @@ context("route rules engine", () => {
     cy.request({
       url: "/thing.jpg",
       redirect: "manual",
-      failOnStatusCode: false
+      failOnStatusCode: false,
     }).as("response");
 
     cy.get("@response").should((response) => {
@@ -158,7 +159,7 @@ context("route rules engine", () => {
     cy.request({
       url: "/thing.png",
       redirect: "manual",
-      failOnStatusCode: false
+      failOnStatusCode: false,
     }).as("response1");
 
     cy.get("@response1").should((response) => {
@@ -168,7 +169,7 @@ context("route rules engine", () => {
     cy.request({
       url: "/thing.gif",
       redirect: "manual",
-      failOnStatusCode: false
+      failOnStatusCode: false,
     }).as("response2");
 
     cy.get("@response2").should((response) => {
@@ -180,19 +181,15 @@ context("route rules engine", () => {
     cy.request({
       url: "/something.google",
       redirect: "manual",
-      failOnStatusCode: false
-    }).as("response");
-
-    cy.get("@response").should((response) => {
+      failOnStatusCode: false,
+    }).then((response) => {
       expect(response.status).to.be(302);
       expect(response.headers.get("location")).to.be("https://www.google.com/");
     });
   });
 
   it("rewrite to folder returns folder's default file", async () => {
-    cy.request("/folder/somefile.html").as("response");
-
-    cy.get("@response").should((response) => {
+    cy.request("/folder/somefile.html").then((response) => {
       expect(response.status).to.be(200);
       cy.title().should("eq", "/folder/index.html");
     });

--- a/cypress/integration/route-rules-engine.js
+++ b/cypress/integration/route-rules-engine.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-context("route rules engine", () => {
+context("route rules engine", { defaultCommandTimeout: 10000 }, () => {
   beforeEach(() => {
     cy.visit("http://0.0.0.0:1234");
   });
@@ -137,24 +137,24 @@ context("route rules engine", () => {
     cy.request("/thing.png").as("response1");
 
     cy.get("@response1")
-    .its("headers")
-    .then((headers) => {
-      expect(headers).to.deep.include({
-        status: "302",
-        location: "http://0.0.0.0:1234/png_gif.html",
+      .its("headers")
+      .then((headers) => {
+        expect(headers).to.deep.include({
+          status: "302",
+          location: "http://0.0.0.0:1234/png_gif.html",
+        });
       });
-    });
 
     cy.request("/thing.gif").as("response2");
 
     cy.get("@response2")
-    .its("headers")
-    .then((headers) => {
-      expect(headers).to.deep.include({
-        status: "302",
-        location: "http://0.0.0.0:1234/png_gif.html",
+      .its("headers")
+      .then((headers) => {
+        expect(headers).to.deep.include({
+          status: "302",
+          location: "http://0.0.0.0:1234/png_gif.html",
+        });
       });
-    });
   });
 
   it("redirect can redirect to external URL", async () => {

--- a/src/auth/routes/auth_login_provider.ts
+++ b/src/auth/routes/auth_login_provider.ts
@@ -1,11 +1,11 @@
+import { IncomingMessage } from "http";
 import { response } from "../../core/utils";
 
 const fs = require("fs").promises;
 const path = require("path");
 
-const httpTrigger = async function (context: Context) {
-  const body = await fs.readFile(path.join(__dirname, "..", "..", "public", "auth.html"));
-
+const httpTrigger = async function (context: Context, request: IncomingMessage) {
+  const body = await fs.readFile(path.join(__dirname, "..", "..", "public", "auth.html"), "utf-8");
   context.res = response({
     context,
     status: 200,
@@ -13,8 +13,19 @@ const httpTrigger = async function (context: Context) {
       "Content-Type": "text/html",
       status: 200,
     },
-    body,
+    body: injectOriginalUrlMetaTags(body, request.url),
   });
 };
+
+function injectOriginalUrlMetaTags(body: string, url?: string): string {
+  // pass original URL to page in case or rewrite
+  if (url) {
+    const [path, search] = url.split("?");
+    const metaTags = `<meta name="swa:originalPath" content="${path}">` + (search ? `<meta name="swa:originalSearch" content="?${search}">` : "");
+    return body.replace(/(<\/head>)/i, `${metaTags}$1`);
+  } else {
+    return body;
+  }
+}
 
 export default httpTrigger;

--- a/src/public/auth.html
+++ b/src/public/auth.html
@@ -169,8 +169,9 @@
       function redirectToApp() {
         const defaultRedirectPath = "/";
         try {
-          const redirectPath = window.location.search || defaultRedirectPath;
-          const urlSearch = location.search.replace("?", "");
+          const metaSearch = document.querySelector(`meta[name="swa:originalSearch"]`)?.content || "";
+          const redirectPath = metaSearch || window.location.search || defaultRedirectPath;
+          const urlSearch = (metaSearch || location.search).replace("?", "");
           const urlQuery = urlSearch && Object.fromEntries(new Map(urlSearch.split("&").map((query) => query.split("="))));
           const postLoginRedirectUri = urlQuery ? urlQuery["post_login_redirect_uri"] : redirectPath;
           window.location.href = postLoginRedirectUri || defaultRedirectPath;
@@ -180,7 +181,7 @@
         }
       }
       function parseIdentityProviderFromUrl() {
-        const pathname = window.location.pathname;
+        const pathname = document.querySelector(`meta[name="swa:originalPath"]`)?.content || window.location.pathname;
         if (pathname.startsWith("/.auth/login")) {
           return pathname.split("/").pop();
         } else {


### PR DESCRIPTION
Inject meta tags into page to maintain path and query string in case of rewrite.

Fixes #165 