### PR TITLE
fix: cors not working

### DIFF
--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -87,7 +87,7 @@ export async function start(startContext: string, options: SWACLIConfig) {
       const funcBinary = "func";
       // serve the api if and only if the user provides a folder via the --api-location flag
       if (isApiLocationExistsOnDisk) {
-        serveApiCommand = `cd ${userConfig.apiLocation} && ${funcBinary} start --cors * --port ${options.apiPort}`;
+        serveApiCommand = `cd ${userConfig.apiLocation} && ${funcBinary} start --cors "*" --port ${options.apiPort}`;
       }
     }
   }


### PR DESCRIPTION
In the current version, CORS are not enabled properly on the function emulator. Without quotes, the `*` will be expanded which is not really the intent here.

Tested the fix locally with a Svelte project, it fixes the issue.