### PR TITLE
fix: move port validation and waiting logic into proxy server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1751,7 +1751,7 @@
     },
     "@types/cookie": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz",
+      "resolved": false,
       "integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==",
       "dev": true
     },
@@ -1856,7 +1856,7 @@
     },
     "@types/mock-fs": {
       "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.0.tgz",
+      "resolved": false,
       "integrity": "sha512-FUqxhURwqFtFBCuUj3uQMp7rPSQs//b3O9XecAVxhqS9y4/W8SIJEZFq2mmpnFVZBXwR/2OyPLE97CpyYiB8Mw==",
       "dev": true,
       "requires": {
@@ -1898,7 +1898,7 @@
     },
     "@types/shelljs": {
       "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.8.tgz",
+      "resolved": false,
       "integrity": "sha512-lD3LWdg6j8r0VRBFahJVaxoW0SIcswxKaFUrmKl33RJVeeoNYQAz4uqCJ5Z6v4oIBOsC5GozX+I5SorIKiTcQA==",
       "dev": true,
       "requires": {
@@ -4925,7 +4925,7 @@
     },
     "jest": {
       "version": "26.6.3",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
+      "resolved": false,
       "integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
       "dev": true,
       "requires": {
@@ -8066,7 +8066,7 @@
     },
     "mock-fs": {
       "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
+      "resolved": false,
       "integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA==",
       "dev": true
     },
@@ -9998,7 +9998,7 @@
     },
     "supertest": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-4.0.2.tgz",
+      "resolved": false,
       "integrity": "sha512-1BAbvrOZsGA3YTCWqbmh14L0YEq0EGICX/nBnfkfVJn7SrxQV1I3pMYjSzG9y/7ZU2V9dWqyqk2POwxlb09duQ==",
       "dev": true,
       "requires": {

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -3,15 +3,7 @@ import fs from "fs";
 import path from "path";
 import { DEFAULT_CONFIG } from "../../config";
 import builder from "../../core/builder";
-import {
-  createStartupScriptCommand,
-  isAcceptingTcpConnections,
-  isHttpUrl,
-  logger,
-  parseUrl,
-  readWorkflowFile,
-  validateDevServerConfig,
-} from "../../core";
+import { createStartupScriptCommand, isAcceptingTcpConnections, isHttpUrl, logger, parseUrl, readWorkflowFile } from "../../core";
 
 export async function start(startContext: string, options: SWACLIConfig) {
   // WARNING: code below doesn't have access to SWA CLI env vars which are defined later below
@@ -22,7 +14,7 @@ export async function start(startContext: string, options: SWACLIConfig) {
   let startupCommand: string | undefined | null = undefined;
 
   if (isHttpUrl(startContext)) {
-    useAppDevServer = await validateDevServerConfig(startContext);
+    useAppDevServer = startContext;
     options.outputLocation = useAppDevServer;
   } else {
     // make sure the CLI default port is available before proceeding.
@@ -45,7 +37,7 @@ export async function start(startContext: string, options: SWACLIConfig) {
 
   if (options.apiLocation) {
     if (isHttpUrl(options.apiLocation)) {
-      useApiDevServer = await validateDevServerConfig(options.apiLocation);
+      useApiDevServer = options.apiLocation;
       options.apiLocation = useApiDevServer;
     }
     // make sure api folder exists

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -10,7 +10,7 @@ import path from "path";
 import serveStatic from "serve-static";
 import { processAuth } from "../auth/";
 import { DEFAULT_CONFIG } from "../config";
-import { address, decodeCookie, findSWAConfigFile, isHttpUrl, logger, registerProcessExit, validateCookie } from "../core";
+import { address, decodeCookie, findSWAConfigFile, isHttpUrl, logger, registerProcessExit, validateCookie, validateDevServerConfig } from "../core";
 import { applyRules } from "./routes-engine/index";
 
 const SWA_WORKFLOW_CONFIG_FILE = process.env.SWA_WORKFLOW_CONFIG_FILE as string;
@@ -263,6 +263,7 @@ const requestHandler = (userConfig: SWAConfigFile | null) =>
 
   const onServerStart = async () => {
     if (isStaticDevServer) {
+      await validateDevServerConfig(SWA_CLI_OUTPUT_LOCATION);
       // prettier-ignore
       logger.log(
         `\nUsing dev server for static content:\n`+
@@ -323,6 +324,15 @@ const requestHandler = (userConfig: SWAConfigFile | null) =>
     }
     return http.createServer(requestHandler(userConfig));
   };
+
+  if (isStaticDevServer) {
+    await validateDevServerConfig(SWA_CLI_OUTPUT_LOCATION);
+  }
+  const isApi = Boolean(SWA_CLI_API_LOCATION && SWA_CLI_API_URI);
+  if (isApi) {
+    await validateDevServerConfig(SWA_CLI_API_URI);
+  }
+
   const server = createServer();
   server.listen(SWA_CLI_PORT, SWA_CLI_HOST, onServerStart);
   server.listen(SWA_CLI_PORT, localIpAdress);

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -263,7 +263,6 @@ const requestHandler = (userConfig: SWAConfigFile | null) =>
 
   const onServerStart = async () => {
     if (isStaticDevServer) {
-      await validateDevServerConfig(SWA_CLI_OUTPUT_LOCATION);
       // prettier-ignore
       logger.log(
         `\nUsing dev server for static content:\n`+


### PR DESCRIPTION
Move wait for port logic into the proxy.

* Running `swa start http://localhost:3000 --run "npm:start" --app-location frontend` now works properly
* Moving the wait for API to just before starting the proxy means most of the function app output now prints before the proxy starts. This ensures that this message will no longer be hidden by the function app output:
    ```
    [swa] Available on:
    [swa]     http://192.168.187.166:4280
    [swa]     http://0.0.0.0:4280
    [swa] 
    [swa] Azure Static Web Apps emulator started. Press CTRL+C to exit.
    ```