### PR TITLE
fix: SSL option error message

### DIFF
--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -86,7 +86,7 @@ export async function start(startContext: string, options: SWACLIConfig) {
 
   if (options.ssl) {
     if (options.sslCert === undefined || options.sslKey === undefined) {
-      logger.error(`SSL Key or SSL Cert are required when using HTTPS`, true);
+      logger.error(`SSL Key and SSL Cert are required when using HTTPS`, true);
     }
   }
 


### PR DESCRIPTION
Change the error message in case if only one of the options '--ssl-cert' or '--ssl-key' is specified because the SSL feature requires both of the options.