### PR TITLE
fix: redirect to the url which starts with `https://` when logged out if `swa` is started with `--ssl` flag

### DIFF
--- a/src/auth/routes/auth_logout.spec.ts
+++ b/src/auth/routes/auth_logout.spec.ts
@@ -66,4 +66,18 @@ describe("auth_logout", () => {
     expect(context.res.headers?.Location).toBe("http://127.0.0.1:4280/foobar");
     expect(context.res.cookies?.[0]).toEqual(deletedCookieDefinition);
   });
+
+  it("should handle protocol with ssl", async () => {
+    process.env.SWA_CLI_APP_SSL = "true";
+    await httpTrigger(context, {
+      headers: {
+        host: "0.0.0.0",
+      },
+    } as IncomingMessage);
+
+    expect(context.res.body).toBe(null);
+    expect(context.res.status).toBe(302);
+    expect(context.res.headers?.Location).toBe("https://0.0.0.0/");
+    expect(context.res.cookies?.[0]).toEqual(deletedCookieDefinition);
+  });
 });

--- a/src/auth/routes/auth_logout.ts
+++ b/src/auth/routes/auth_logout.ts
@@ -11,7 +11,7 @@ const httpTrigger = async function (context: Context, req: http.IncomingMessage)
     return;
   }
 
-  const uri = `http${process.env.SWA_CLI_APP_SSL === "true" ? "s" : ""}://${host}`;
+  const uri = `${process.env.SWA_CLI_APP_SSL === "true" ? "https" : "http"}://${host}`;
   const query = new URL(req?.url || "", uri).searchParams;
   const location = `${uri}${query.get("post_logout_redirect_uri") || "/"}`;
 

--- a/src/auth/routes/auth_logout.ts
+++ b/src/auth/routes/auth_logout.ts
@@ -11,7 +11,7 @@ const httpTrigger = async function (context: Context, req: http.IncomingMessage)
     return;
   }
 
-  const uri = `http://${host}`;
+  const uri = `http${process.env.SWA_CLI_APP_SSL === "true" ? "s" : ""}://${host}`;
   const query = new URL(req?.url || "", uri).searchParams;
   const location = `${uri}${query.get("post_logout_redirect_uri") || "/"}`;
 

--- a/src/auth/routes/auth_logout_https.spec.ts
+++ b/src/auth/routes/auth_logout_https.spec.ts
@@ -1,9 +1,12 @@
 import { IncomingMessage } from "http";
 import httpTrigger from "./auth_logout";
 
-describe("auth_logout", () => {
+describe("auth_logout_https", () => {
   let context: Context;
   let req: IncomingMessage;
+
+  const SWA_CLI_APP_SSL_BUFFER = process.env.SWA_CLI_APP_SSL;
+  process.env.SWA_CLI_APP_SSL = "true";
 
   const deletedCookieDefinition = {
     name: "StaticWebAppsAuthCookie",
@@ -20,14 +23,14 @@ describe("auth_logout", () => {
     } as IncomingMessage;
   });
 
-  it("should handle empty config", async () => {
+  it("should handle empty config (https)", async () => {
     await httpTrigger(context, req);
 
     expect(context.res.body).toBe(null);
     expect(context.res.status).toBe(500);
   });
 
-  it("should handle host without port", async () => {
+  it("should handle host without port (https)", async () => {
     await httpTrigger(context, {
       headers: {
         host: "0.0.0.0",
@@ -36,11 +39,11 @@ describe("auth_logout", () => {
 
     expect(context.res.body).toBe(null);
     expect(context.res.status).toBe(302);
-    expect(context.res.headers?.Location).toBe("http://0.0.0.0/");
+    expect(context.res.headers?.Location).toBe("https://0.0.0.0/");
     expect(context.res.cookies?.[0]).toEqual(deletedCookieDefinition);
   });
 
-  it("should handle host with port", async () => {
+  it("should handle host with port (https)", async () => {
     await httpTrigger(context, {
       headers: {
         host: "127.0.0.1:4280",
@@ -49,11 +52,11 @@ describe("auth_logout", () => {
 
     expect(context.res.body).toBe(null);
     expect(context.res.status).toBe(302);
-    expect(context.res.headers?.Location).toBe("http://127.0.0.1:4280/");
+    expect(context.res.headers?.Location).toBe("https://127.0.0.1:4280/");
     expect(context.res.cookies?.[0]).toEqual(deletedCookieDefinition);
   });
 
-  it("should handle post_logout_redirect_uri", async () => {
+  it("should handle post_logout_redirect_uri (https)", async () => {
     await httpTrigger(context, {
       url: "/.auth/logout?post_logout_redirect_uri=/foobar",
       headers: {
@@ -63,7 +66,11 @@ describe("auth_logout", () => {
 
     expect(context.res.body).toBe(null);
     expect(context.res.status).toBe(302);
-    expect(context.res.headers?.Location).toBe("http://127.0.0.1:4280/foobar");
+    expect(context.res.headers?.Location).toBe("https://127.0.0.1:4280/foobar");
     expect(context.res.cookies?.[0]).toEqual(deletedCookieDefinition);
+  });
+
+  afterAll(() => {
+    process.env.SWA_CLI_APP_SSL = SWA_CLI_APP_SSL_BUFFER;
   });
 });


### PR DESCRIPTION
Currently, a request to `/.auth/logout` always is redirect to `http://`.
https://github.com/Azure/static-web-apps-cli/blob/db13f3a2646759b5b917733e4eb895674539b345/src/auth/routes/auth_logout.ts#L14

Because this causes a redirection to an invalid URL when `swa` is started with `--ssl` flag, this PR switches the protocol of URL by the value of `process.env.SWA_CLI_APP_SSL`.