### PR TITLE
feat: handle `x-forwarded-host/proto` headers on logging out

### DIFF
--- a/src/auth/routes/auth_logout.spec.ts
+++ b/src/auth/routes/auth_logout.spec.ts
@@ -69,7 +69,7 @@ describe("auth_logout", () => {
 
   it("should handle x-forwarded-host header", async () => {
     await httpTrigger(context, {
-      url: "/.auth/logout?post_logout_redirect_uri=/foobar",
+      url: "/.auth/logout",
       headers: {
         host: "127.0.0.1:4280",
         "x-forwarded-host": "0.0.0.0:8080"
@@ -78,7 +78,23 @@ describe("auth_logout", () => {
 
     expect(context.res.body).toBe(null);
     expect(context.res.status).toBe(302);
-    expect(context.res.headers?.Location).toBe("http://0.0.0.0:8080/foobar");
+    expect(context.res.headers?.Location).toBe("http://0.0.0.0:8080/");
+    expect(context.res.cookies?.[0]).toEqual(deletedCookieDefinition);
+  });
+
+  it("should handle x-forwarded-proto header", async () => {
+    await httpTrigger(context, {
+      url: "/.auth/logout",
+      headers: {
+        host: "127.0.0.1:4280",
+        "x-forwarded-host": "0.0.0.0:8080",
+        "x-forwarded-proto": "https"
+      } as NodeJS.Dict<string | string[]>
+    } as IncomingMessage);
+
+    expect(context.res.body).toBe(null);
+    expect(context.res.status).toBe(302);
+    expect(context.res.headers?.Location).toBe("https://0.0.0.0:8080/");
     expect(context.res.cookies?.[0]).toEqual(deletedCookieDefinition);
   });
 });

--- a/src/auth/routes/auth_logout.spec.ts
+++ b/src/auth/routes/auth_logout.spec.ts
@@ -66,4 +66,19 @@ describe("auth_logout", () => {
     expect(context.res.headers?.Location).toBe("http://127.0.0.1:4280/foobar");
     expect(context.res.cookies?.[0]).toEqual(deletedCookieDefinition);
   });
+
+  it("should handle x-forwarded-host header", async () => {
+    await httpTrigger(context, {
+      url: "/.auth/logout?post_logout_redirect_uri=/foobar",
+      headers: {
+        host: "127.0.0.1:4280",
+        "x-forwarded-host": "0.0.0.0:8080"
+      } as NodeJS.Dict<string | string[]>
+    } as IncomingMessage);
+
+    expect(context.res.body).toBe(null);
+    expect(context.res.status).toBe(302);
+    expect(context.res.headers?.Location).toBe("http://0.0.0.0:8080/foobar");
+    expect(context.res.cookies?.[0]).toEqual(deletedCookieDefinition);
+  });
 });

--- a/src/auth/routes/auth_logout.ts
+++ b/src/auth/routes/auth_logout.ts
@@ -2,7 +2,8 @@ import http from "http";
 import { response } from "../../core";
 
 const httpTrigger = async function (context: Context, req: http.IncomingMessage) {
-  const host = req?.headers?.host;
+  const headers = req?.headers;
+  const host = headers ? (headers["x-forwarded-host"] || headers.host) : undefined;
   if (!host) {
     context.res = response({
       context,

--- a/src/auth/routes/auth_logout.ts
+++ b/src/auth/routes/auth_logout.ts
@@ -12,7 +12,7 @@ const httpTrigger = async function (context: Context, req: http.IncomingMessage)
     return;
   }
 
-  const uri = `${process.env.SWA_CLI_APP_SSL === "true" ? "https" : "http"}://${host}`;
+  const uri = `${headers["x-forwarded-proto"] || (process.env.SWA_CLI_APP_SSL === "true" ? "https" : "http")}://${host}`;
   const query = new URL(req?.url || "", uri).searchParams;
   const location = `${uri}${query.get("post_logout_redirect_uri") || "/"}`;
 


### PR DESCRIPTION
This PR makes a redirection URL for logging out based on `X-Forwarded-Host` and `X-Forwarded-Proto`.
Currently, the host in the redirection URL for logging out depends on only the `Host` header and the protocol depends on only env `SWA_CLI_APP_SSL`.

Background:
It is confirmed that the redirection URL is always `http://localhost` when SWA-CLI works in a Dev Container on GitHub Codespaces.
I think this is because of the existence of the proxy and `X-Forwarded-` headers can be used for building the appropriate redirection URL.