### PR TITLE
feat: allow --run to take any command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,22 @@ To use SWA CLI with your local dev server, follow these two steps:
    swa start http://<APP_DEV_SERVER_HOST>:<APP_DEV_SERVER_PORT>
    ```
 
+Instead of starting a dev server separately, you can provide the startup command to the CLI.
+
+```bash
+# npm start script (React)
+swa start http://localhost:3000 --run "npm start"
+
+# dotnet watch (Blazor)
+swa start http://localhost:5000 --run "dotnet watch run"
+
+# Jekyll
+swa start http://localhost:4000 --run "jekyll serve"
+
+# custom script
+swa start http://localhost:4200 --run "./startup.sh"
+```
+
 Here is a list of the default ports used by some popular dev servers:
 
 | Tool                                                                               | Port | Command                           |

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -43,7 +43,7 @@ exports.run = async function () {
     .option("--ssl-cert <sslCertLocation>", "SSL certificate (.crt) to use for serving HTTPS", DEFAULT_CONFIG.sslCert)
     .option("--ssl-key <sslKeyLocation>", "SSL key (.key) to use for serving HTTPS", DEFAULT_CONFIG.sslKey)
 
-    .addOption(new Option("--run <startupScript>", "run a external program or npm/yarn script on startup").default(DEFAULT_CONFIG.run).hideHelp())
+    .option("--run <startupScript>", "run a command at startup", DEFAULT_CONFIG.run)
 
     .action(async (context: string = `.${path.sep}`, options: SWACLIConfig) => {
       options = {
@@ -67,9 +67,6 @@ exports.run = async function () {
       `
 Examples:
 
-  Serve static content from the current folder
-  swa start
-
   Serve static content from a specific folder
   swa start ./output-folder
 
@@ -81,6 +78,9 @@ Examples:
 
   Serve static content and run an API from another folder
   swa start ./output-folder --api ./api
+
+  Use a custom command to run framework development server at startup
+  swa start http://localhost:3000 --run "npm start"
     `
     );
 

--- a/src/core/utils/cli.spec.ts
+++ b/src/core/utils/cli.spec.ts
@@ -140,7 +140,7 @@ describe("createStartupScriptCommand()", () => {
       expect(cmd).toBe("/foo/script.sh");
     });
   });
-  describe("non-valid use cases", () => {
+  xdescribe("non-valid use cases", () => {
     it("should handle non-valid npm patterns", () => {
       const cmd = createStartupScriptCommand("npm", {});
       expect(cmd).toBe(null);

--- a/src/core/utils/cli.spec.ts
+++ b/src/core/utils/cli.spec.ts
@@ -140,30 +140,10 @@ describe("createStartupScriptCommand()", () => {
       expect(cmd).toBe("/foo/script.sh");
     });
   });
-  xdescribe("non-valid use cases", () => {
-    it("should handle non-valid npm patterns", () => {
-      const cmd = createStartupScriptCommand("npm", {});
-      expect(cmd).toBe(null);
-    });
-    it("should handle non-valid yarn patterns", () => {
-      const cmd = createStartupScriptCommand("yarn", {});
-      expect(cmd).toBe(null);
-    });
-    it("should handle non-valid npx patterns", () => {
-      const cmd = createStartupScriptCommand("npx", {});
-      expect(cmd).toBe(null);
-    });
-    it("should handle non-existant scripts (relative)", () => {
-      const cmd = createStartupScriptCommand("script.sh", {});
-      expect(cmd).toBe(null);
-    });
-    it("should handle non-existant scripts (asbolute)", () => {
-      const cmd = createStartupScriptCommand("/foo/bar/script.sh", {});
-      expect(cmd).toBe(null);
-    });
-    it("should handle non-existant scripts (asbolute)", () => {
-      const cmd = createStartupScriptCommand(`"npm:µ˜¬…˚πº–ª¶§∞¢£¢™§_)(*!#˜%@)`, {});
-      expect(cmd).toBe(null);
+  describe("custom command", () => {
+    it("should return custom command", () => {
+      const cmd = createStartupScriptCommand("dotnet watch run", {});
+      expect(cmd).toBe("dotnet watch run");
     });
   });
 });

--- a/src/core/utils/cli.ts
+++ b/src/core/utils/cli.ts
@@ -1,5 +1,5 @@
-// import path from "path";
-// import fs from "fs";
+import path from "path";
+import fs from "fs";
 // import { logger } from "./logger";
 
 /**
@@ -80,7 +80,7 @@ export function registerProcessExit(callback: Function) {
  * @param options The SWA CLI configuration flags.
  * @returns
  */
-export const createStartupScriptCommand = (startupScript: string, _options: SWACLIConfig) => {
+export const createStartupScriptCommand = (startupScript: string, options: SWACLIConfig) => {
   if (startupScript.includes(":")) {
     const [npmOrYarnBin, ...npmOrYarnScript] = startupScript.split(":");
     if (["npm", "yarn"].includes(npmOrYarnBin)) {
@@ -89,7 +89,15 @@ export const createStartupScriptCommand = (startupScript: string, _options: SWAC
       return `${npmOrYarnBin} ${npmOrYarnScript.join(":")}`;
     }
   } else {
+    if (!path.isAbsolute(startupScript)) {
+      const { appLocation } = options;
+      const cwd = appLocation || process.cwd();
+      const absoluteStartupScript = path.resolve(cwd, startupScript);
+      if (fs.existsSync(absoluteStartupScript)) {
+        startupScript = absoluteStartupScript;
+      }
+    }
     return startupScript;
   }
   return null;
-}
+};

--- a/src/core/utils/cli.ts
+++ b/src/core/utils/cli.ts
@@ -1,6 +1,5 @@
 import path from "path";
 import fs from "fs";
-// import { logger } from "./logger";
 
 /**
  * Parse process.argv and retrieve a specific flag value.
@@ -80,7 +79,7 @@ export function registerProcessExit(callback: Function) {
  * @param options The SWA CLI configuration flags.
  * @returns
  */
-export const createStartupScriptCommand = (startupScript: string, options: SWACLIConfig) => {
+export function createStartupScriptCommand(startupScript: string, options: SWACLIConfig) {
   if (startupScript.includes(":")) {
     const [npmOrYarnBin, ...npmOrYarnScript] = startupScript.split(":");
     if (["npm", "yarn"].includes(npmOrYarnBin)) {
@@ -100,4 +99,4 @@ export const createStartupScriptCommand = (startupScript: string, options: SWACL
     return startupScript;
   }
   return null;
-};
+}

--- a/src/core/utils/cli.ts
+++ b/src/core/utils/cli.ts
@@ -1,6 +1,6 @@
-import path from "path";
-import fs from "fs";
-import { logger } from "./logger";
+// import path from "path";
+// import fs from "fs";
+// import { logger } from "./logger";
 
 /**
  * Parse process.argv and retrieve a specific flag value.
@@ -80,7 +80,7 @@ export function registerProcessExit(callback: Function) {
  * @param options The SWA CLI configuration flags.
  * @returns
  */
-export function createStartupScriptCommand(startupScript: string, options: SWACLIConfig) {
+export const createStartupScriptCommand = (startupScript: string, _options: SWACLIConfig) => {
   if (startupScript.includes(":")) {
     const [npmOrYarnBin, ...npmOrYarnScript] = startupScript.split(":");
     if (["npm", "yarn"].includes(npmOrYarnBin)) {
@@ -89,17 +89,7 @@ export function createStartupScriptCommand(startupScript: string, options: SWACL
       return `${npmOrYarnBin} ${npmOrYarnScript.join(":")}`;
     }
   } else {
-    if (!path.isAbsolute(startupScript)) {
-      const { appLocation } = options;
-      const cwd = appLocation || process.cwd();
-      startupScript = path.resolve(cwd, startupScript);
-    }
-
-    if (fs.existsSync(startupScript)) {
-      return startupScript;
-    } else {
-      logger.error(`Script file "${startupScript}" was not found.`, true);
-    }
+    return startupScript;
   }
   return null;
 }


### PR DESCRIPTION
Resolves #147 

Support passing arbitrary commands to `--run`, such as:
* `swa start http://localhost:5000 --run "dotnet watch run"`
* `swa start http://localhost:5000 --run "cd MyApp && dotnet watch run"`