### PR TITLE
fix: always include anonymous & authenticated roles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1751,7 +1751,7 @@
     },
     "@types/cookie": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz",
+      "resolved": false,
       "integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==",
       "dev": true
     },
@@ -1856,7 +1856,7 @@
     },
     "@types/mock-fs": {
       "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.0.tgz",
+      "resolved": false,
       "integrity": "sha512-FUqxhURwqFtFBCuUj3uQMp7rPSQs//b3O9XecAVxhqS9y4/W8SIJEZFq2mmpnFVZBXwR/2OyPLE97CpyYiB8Mw==",
       "dev": true,
       "requires": {
@@ -1921,7 +1921,7 @@
     },
     "@types/shelljs": {
       "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.8.tgz",
+      "resolved": false,
       "integrity": "sha512-lD3LWdg6j8r0VRBFahJVaxoW0SIcswxKaFUrmKl33RJVeeoNYQAz4uqCJ5Z6v4oIBOsC5GozX+I5SorIKiTcQA==",
       "dev": true,
       "requires": {
@@ -4968,7 +4968,7 @@
     },
     "jest": {
       "version": "26.6.3",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
+      "resolved": false,
       "integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
       "dev": true,
       "requires": {
@@ -10042,7 +10042,7 @@
     },
     "supertest": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-4.0.2.tgz",
+      "resolved": false,
       "integrity": "sha512-1BAbvrOZsGA3YTCWqbmh14L0YEq0EGICX/nBnfkfVJn7SrxQV1I3pMYjSzG9y/7ZU2V9dWqyqk2POwxlb09duQ==",
       "dev": true,
       "requires": {

--- a/src/public/auth.html
+++ b/src/public/auth.html
@@ -162,6 +162,7 @@
     <script src="https://ajax.aspnetcdn.com/ajax/jquery/jquery-3.2.1.min.js" crossorigin="anonymous"></script>
     <script src="https://ajax.aspnetcdn.com/ajax/bootstrap/4.1.1/bootstrap.min.js" crossorigin="anonymous"></script>
     <script>
+      const defaultRoles = ["anonymous", "authenticated"];
       function saveCookie(formElement) {
         const data = localStorage[hashStorageKey(formElement)];
         document.cookie = `StaticWebAppsAuthCookie=${btoa(data)}; path=/`;
@@ -229,7 +230,8 @@
           const inputValue = element.val();
           let data = JSON.parse(localStorage[storageKey]);
           if (inputName === "userRoles") {
-            data[inputName] = inputValue.trim().split("\n");
+            // ensure default roles are included
+            data[inputName] = [...new Set([...inputValue.trim().split("\n"), ...defaultRoles])];
           } else {
             data[inputName] = inputValue;
           }
@@ -287,7 +289,6 @@
     <script>
       $(function () {
         // setup default values
-        const defaultRoles = ["anonymous", "authenticated"];
         const form = $("form[name='auth']");
 
         // trigger on first call


### PR DESCRIPTION
If anonymous or authenticated are not entered by the user, they are not always included when evaluating routes or in APIs. Making a change so that the cookie always includes them.