### PR TITLE
feat: Configure await timeout before connecting to a dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.6.2-alpha",
   "description": "Azure Static Web Apps CLI",
   "scripts": {
-    "start": "node ./dist/cli/bin.js start ./cypress/fixtures/static --api=./cypress/fixtures/api --port 1234 --verbose silly",
+    "start": "node ./dist/cli/bin.js start ./cypress/fixtures/static --api=./cypress/fixtures/api --port 1234 --devserver-timeout 10000 --verbose silly",
     "prestart": "npm run build",
     "pretest": "npm run build",
     "test": "jest --detectOpenHandles --silent --verbose",

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -53,6 +53,8 @@ export async function start(startContext: string, options: SWACLIConfig) {
   let [appLocation, outputLocation, apiLocation] = [options.appLocation as string, options.outputLocation as string, options.apiLocation as string];
 
   let apiPort = (options.apiPort || DEFAULT_CONFIG.apiPort) as number;
+  let devserverTimeout = (options.devserverTimeout || DEFAULT_CONFIG.devserverTimeout) as number;
+
   let userWorkflowConfig: Partial<GithubActionWorkflow> | undefined = {
     appLocation,
     outputLocation,
@@ -115,6 +117,7 @@ export async function start(startContext: string, options: SWACLIConfig) {
     SWA_CLI_APP_SSL_KEY: options.sslKey,
     SWA_CLI_STARTUP_COMMAND: startupCommand as string,
     SWA_CLI_VERSION: packageInfo.version,
+    SWA_CLI_DEVSERVER_TIMEOUT: `${devserverTimeout}`,
   };
 
   // merge SWA env variables with process.env

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,7 @@
 import program, { Option } from "commander";
 import path from "path";
 import { DEFAULT_CONFIG } from "../config";
-import { parsePort } from "../core";
+import { parsePort, parseTime } from "../core";
 import { start } from "./commands/start";
 import updateNotifier from "update-notifier";
 const pkg = require("../../package.json");
@@ -49,6 +49,12 @@ export async function run(argv?: string[]) {
     .option("--ssl-key <sslKeyLocation>", "SSL key (.key) to use for serving HTTPS", DEFAULT_CONFIG.sslKey)
 
     .option("--run <startupScript>", "run a command at startup", DEFAULT_CONFIG.run)
+    .option<number>(
+      "--devserver-timeout <devserverTimeout>",
+      "time to wait(in ms) for the dev server to start",
+      parseTime,
+      DEFAULT_CONFIG.devserverTimeout
+    )
 
     .action(async (context: string = `.${path.sep}`, options: SWACLIConfig) => {
       options = {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,8 @@
 import program, { Option } from "commander";
 import path from "path";
 import { DEFAULT_CONFIG } from "../config";
-import { parsePort, parseTime } from "../core";
+import { parsePort } from "../core";
+import { parseDevserverTimeout } from "../core";
 import { start } from "./commands/start";
 import updateNotifier from "update-notifier";
 const pkg = require("../../package.json");
@@ -52,7 +53,7 @@ export async function run(argv?: string[]) {
     .option<number>(
       "--devserver-timeout <devserverTimeout>",
       "time to wait(in ms) for the dev server to start",
-      parseTime,
+      parseDevserverTimeout,
       DEFAULT_CONFIG.devserverTimeout
     )
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,4 +18,5 @@ export const DEFAULT_CONFIG: SWACLIConfig = {
   verbose: "log",
   customUrlScheme: "swa://",
   overridableErrorCode: [400, 401, 403, 404],
+  devserverTimeout: 30000,
 };

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -173,6 +173,7 @@ export const SWA_CLI_APP_SSL_CERT = process.env.SWA_CLI_APP_SSL_CERT as string;
 export const SWA_CLI_APP_PROTOCOL = SWA_CLI_APP_SSL ? `https` : `http`;
 export const SWA_PUBLIC_DIR = path.resolve(__dirname, "..", "public");
 export const HAS_API = Boolean(SWA_CLI_API_LOCATION && SWA_CLI_API_URI());
+export const SWA_CLI_DEVSERVER_TIMEOUT = parseInt((process.env.SWA_CLI_DEVSERVER_TIMEOUT || DEFAULT_CONFIG.devserverTimeout) as string, 10);
 
 // --
 // Note: declare these as functions so that their body gets evaluated at runtime!

--- a/src/core/utils/cli.spec.ts
+++ b/src/core/utils/cli.spec.ts
@@ -1,7 +1,8 @@
 jest.mock("../constants", () => {});
 import mockFs from "mock-fs";
 import path from "path";
-import { argv, createStartupScriptCommand } from "./cli";
+import { argv, createStartupScriptCommand, parseDevserverTimeout } from "./cli";
+import { logger } from "./logger";
 
 describe("argv()", () => {
   it("process.argv = []", () => {
@@ -144,6 +145,27 @@ describe("createStartupScriptCommand()", () => {
     it("should return custom command", () => {
       const cmd = createStartupScriptCommand("dotnet watch run", {});
       expect(cmd).toBe("dotnet watch run");
+    });
+  });
+
+  describe("parseDevserverTimeout()", () => {
+    const mockLoggerError = jest.spyOn(logger, "error").mockImplementation(() => {
+      return undefined as never;
+    });
+
+    it("DevserverTimeout below 0 should be invalid", () => {
+      parseDevserverTimeout("-10");
+      expect(mockLoggerError).toBeCalled();
+    });
+
+    it("DevserverTimeout for any positive value should be valid", () => {
+      const timeValue = parseDevserverTimeout("30000");
+      expect(timeValue).toBe(30000);
+    });
+
+    it("Non-number DevserverTimeout should be invalid", () => {
+      parseDevserverTimeout("not a number");
+      expect(mockLoggerError).toBeCalled();
     });
   });
 });

--- a/src/core/utils/cli.ts
+++ b/src/core/utils/cli.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import fs from "fs";
+import { logger } from "./logger";
 
 /**
  * Parse process.argv and retrieve a specific flag value.
@@ -99,4 +100,20 @@ export function createStartupScriptCommand(startupScript: string, options: SWACL
     return startupScript;
   }
   return null;
+}
+
+/**
+ * Parses the string devserver-timeout and returns an integer
+ * @param time devserver-timeout flag as string
+ * @returns parses the string and returns an integer
+ */
+export function parseDevserverTimeout(time: string) {
+  //The argument 10 implies to convert the given string to base-10(decimal)
+  const timeValue = parseInt(time, 10);
+  if (isNaN(timeValue)) {
+    logger.error(`--devserser-timeout should be a number expressed in milliseconds. Got "${time}".`, true);
+  } else if (timeValue < 0) {
+    logger.error(`--devserser-timeout should be a positive number`);
+  }
+  return timeValue;
 }

--- a/src/core/utils/net.ts
+++ b/src/core/utils/net.ts
@@ -157,12 +157,3 @@ export function hostnameToIpAdress(hostnameOrIpAddress: string | undefined) {
   }
   return hostnameOrIpAddress;
 }
-
-export function parseTime(time: string) {
-  //The argument 10 implies to convert the given string to base-10(decimal)
-  const timeValue = parseInt(time, 10);
-  if (isNaN(timeValue)) {
-    logger.error(`Time "${time} is not a number.`, true);
-  }
-  return timeValue;
-}

--- a/src/core/utils/net.ts
+++ b/src/core/utils/net.ts
@@ -45,7 +45,7 @@ export function isHttpUrl(url: string) {
  * @param timeout Maximum time in ms to wait before exiting with failure (1) code,
   default Infinity.
  */
-export async function validateDevServerConfig(context: string, timeout = 30000) {
+export async function validateDevServerConfig(context: string, timeout: number) {
   let { hostname, port } = parseUrl(context);
 
   try {
@@ -156,4 +156,13 @@ export function hostnameToIpAdress(hostnameOrIpAddress: string | undefined) {
     return "127.0.0.1";
   }
   return hostnameOrIpAddress;
+}
+
+export function parseTime(time: string) {
+  //The argument 10 implies to convert the given string to base-10(decimal)
+  const timeValue = parseInt(time, 10);
+  if (isNaN(timeValue)) {
+    logger.error(`Time "${time} is not a number.`, true);
+  }
+  return timeValue;
 }

--- a/src/msha/server.ts
+++ b/src/msha/server.ts
@@ -22,6 +22,7 @@ import {
   SWA_CLI_PORT,
   SWA_CLI_ROUTES_LOCATION,
   SWA_WORKFLOW_CONFIG_FILE,
+  SWA_CLI_DEVSERVER_TIMEOUT,
 } from "../core/constants";
 import { validateFunctionTriggers } from "./handlers/function.handler";
 import { handleUserConfig, onConnectionLost, requestMiddleware } from "./middlewares/request.middleware";
@@ -154,11 +155,11 @@ function onServerStart(server: https.Server | http.Server, socketConnection: net
   };
 
   if (IS_APP_DEV_SERVER()) {
-    await validateDevServerConfig(SWA_CLI_OUTPUT_LOCATION);
+    await validateDevServerConfig(SWA_CLI_OUTPUT_LOCATION, SWA_CLI_DEVSERVER_TIMEOUT);
   }
 
   if (HAS_API) {
-    await validateDevServerConfig(SWA_CLI_API_URI());
+    await validateDevServerConfig(SWA_CLI_API_URI(), SWA_CLI_DEVSERVER_TIMEOUT);
     await validateFunctionTriggers();
   }
 

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -75,6 +75,7 @@ declare type SWACLIConfig = GithubActionWorkflow & {
   swaConfigLocation?: string;
   customUrlScheme?: string;
   overridableErrorCode?: number[];
+  devserverTimeout?: number;
 };
 
 declare type ResponseOptions = {


### PR DESCRIPTION
Resolves #253 
Allows user to configure wait timeout before dev server starts using the flag `--devserver-timeout`, such as:
`swa start --devserver-timeout 10000`