### PR TITLE
feat: Add option to pass arguments to func start command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -179,6 +179,7 @@ If you need to override the default values, provide the following options:
 | `--ssl-key`                      | SSL key to use for serving HTTPS                        |           | `--ssl-key="/home/user/ssl/example.key"`             |
 | `--run`                          | Run a command at startup                                |           | `--run="cd app & npm start"`                         |
 | `--devserver-timeout`            | The time to wait(in ms) for the dev server to start     | 30000     | `--devserver-timeout=60000`                          |
+| `--func-args`                    | Additional arguments to pass to `func start`            |           | `--func-args="--javascript"`                         |
 
 ## Local authentication & authorization emulation
 

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -84,7 +84,9 @@ export async function start(startContext: string, options: SWACLIConfig) {
       const funcBinary = "func";
       // serve the api if and only if the user provides a folder via the --api-location flag
       if (isApiLocationExistsOnDisk) {
-        serveApiCommand = `cd "${userWorkflowConfig.apiLocation}" && ${funcBinary} start --cors "*" --port ${options.apiPort}`;
+        serveApiCommand = `cd "${userWorkflowConfig.apiLocation}" && ${funcBinary} start --cors "*" --port ${options.apiPort} ${
+          options.funcArgs ?? ""
+        }`;
       }
     }
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -57,6 +57,8 @@ export async function run(argv?: string[]) {
       DEFAULT_CONFIG.devserverTimeout
     )
 
+    .option("--func-args <funcArgs>", "pass additional arguments to the func start command")
+
     .action(async (context: string = `.${path.sep}`, options: SWACLIConfig) => {
       options = {
         ...options,

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -76,6 +76,7 @@ declare type SWACLIConfig = GithubActionWorkflow & {
   customUrlScheme?: string;
   overridableErrorCode?: number[];
   devserverTimeout?: number;
+  funcArgs?: string;
 };
 
 declare type ResponseOptions = {


### PR DESCRIPTION
👋

Fixes #289 

Added the `--func-args` option that allows passing additional arguments to the func start command.

I verified that this will enable scenarios like attaching a debugger to the func host.

I verified that this enabled attaching the VS Code debugger to the func host when I used the following command:

`swa start http://localhost:3000/ --app-location=frontend --run "npm run start" --api api --func-args="--javascript --language-worker -- \"--inspect=9229\""`