### PR TITLE
Use sanitizedUrl.search to format search params

### DIFF
--- a/src/msha/routes-engine/route-processor.ts
+++ b/src/msha/routes-engine/route-processor.ts
@@ -128,7 +128,7 @@ export function parseQueryParams(req: http.IncomingMessage, matchingRouteRule: S
   let matchingRewriteRoutePath = matchingRewriteRoute ? matchingRewriteRoute : undefined;
 
   if (doesMatchingRewriteRouteHaveQueryStringParameters) {
-    matchingRewriteRoutePath = sanitizedUrl.pathname + matchingRewriteRouteQueryString;
+    matchingRewriteRoutePath = sanitizedUrl.pathname + sanitizedUrl.search;
     logger.silly(` - query: ${chalk.yellow(matchingRewriteRouteQueryString)}`);
   }
   return { matchingRewriteRoutePath, sanitizedUrl, matchingRewriteRoute };


### PR DESCRIPTION
I was running into an issue with this while setting up a Vite frontend (React template) with the SWA cli.

The change of adding `matchingRewriteRouteQueryString` to the end results in this:

```
[swa] /src/logo.svgimport=
```

Notice the missing `?` prefix.

I instead replaced it with this:

```diff
if (doesMatchingRewriteRouteHaveQueryStringParameters) {
-    matchingRewriteRoutePath = sanitizedUrl.pathname + matchingRewriteRouteQueryString; // => /src/logo.svgimport=
+    matchingRewriteRoutePath = sanitizedUrl.pathname + sanitizedUrl.search;  // => /src/logo.svg?import
    core_1.logger.silly(` - query: ${chalk_1.default.yellow(matchingRewriteRouteQueryString)}`);
}
```

The mapping is now correct.

```
[swa] /src/logo.svg?import
```

And it correctly appends the search params and lets the Vite React starter load correctly.