### PR TITLE
feat: add --open option (closes #357)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "http-proxy": "^1.18.1",
         "internal-ip": "^6.2.0",
         "node-fetch": "^2.6.6",
+        "open": "^8.4.0",
         "ora": "^5.4.1",
         "rimraf": "^3.0.2",
         "serve-static": "^1.14.2",
@@ -4219,6 +4220,14 @@
       "version": "1.1.3",
       "license": "MIT"
     },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/define-property": {
       "version": "2.0.2",
       "dev": true,
@@ -5799,9 +5808,7 @@
     },
     "node_modules/is-docker": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -6000,9 +6007,7 @@
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -9325,6 +9330,22 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -15171,6 +15192,11 @@
     "defer-to-connect": {
       "version": "1.1.3"
     },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
+    },
     "define-property": {
       "version": "2.0.2",
       "dev": true,
@@ -16206,9 +16232,7 @@
       }
     },
     "is-docker": {
-      "version": "2.1.1",
-      "dev": true,
-      "optional": true
+      "version": "2.1.1"
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -16308,8 +16332,6 @@
     },
     "is-wsl": {
       "version": "2.2.0",
-      "dev": true,
-      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -19261,9 +19283,9 @@
       }
     },
     "semver-regex": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
-      "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
+      "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
       "dev": true
     },
     "send": {
@@ -19949,9 +19971,9 @@
       }
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-fast-properties": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18473,6 +18473,16 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "open": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "requires": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      }
+    },
     "opencollective-postinstall": {
       "version": "2.0.3",
       "dev": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -19261,9 +19261,9 @@
       }
     },
     "semver-regex": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
-      "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
+      "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
       "dev": true
     },
     "send": {
@@ -19949,9 +19949,9 @@
       }
     },
     "tmpl": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
-      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
     },
     "to-fast-properties": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "http-proxy": "^1.18.1",
     "internal-ip": "^6.2.0",
     "node-fetch": "^2.6.6",
+    "open": "^8.4.0",
     "ora": "^5.4.1",
     "rimraf": "^3.0.2",
     "serve-static": "^1.14.2",

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -137,6 +137,7 @@ export async function start(startContext: string, options: SWACLIConfig) {
     SWA_CLI_STARTUP_COMMAND: startupCommand as string,
     SWA_CLI_VERSION: packageInfo.version,
     SWA_CLI_DEVSERVER_TIMEOUT: `${devserverTimeout}`,
+    SWA_CLI_OPEN: `${options.open}`,
   };
 
   // merge SWA env variables with process.env

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -57,6 +57,7 @@ export async function run(argv?: string[]) {
       DEFAULT_CONFIG.devserverTimeout
     )
 
+    .option("--open", "open the browser to the dev server", DEFAULT_CONFIG.open)
     .option("--func-args <funcArgs>", "pass additional arguments to the func start command")
 
     .action(async (context: string = `.${path.sep}`, options: SWACLIConfig) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,4 +19,5 @@ export const DEFAULT_CONFIG: SWACLIConfig = {
   customUrlScheme: "swa://",
   overridableErrorCode: [400, 401, 403, 404],
   devserverTimeout: 30000,
+  open: false,
 };

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -174,6 +174,7 @@ export const SWA_CLI_APP_PROTOCOL = SWA_CLI_APP_SSL ? `https` : `http`;
 export const SWA_PUBLIC_DIR = path.resolve(__dirname, "..", "public"); //SWA_PUBLIC_DIR = "../public"
 export const HAS_API = Boolean(SWA_CLI_API_LOCATION && SWA_CLI_API_URI());
 export const SWA_CLI_DEVSERVER_TIMEOUT = parseInt((process.env.SWA_CLI_DEVSERVER_TIMEOUT || DEFAULT_CONFIG.devserverTimeout) as string, 10);
+export const SWA_CLI_OPEN = (process.env.SWA_CLI_OPEN === "true" || DEFAULT_CONFIG.open) as boolean;
 
 // --
 // Note: declare these as functions so that their body gets evaluated at runtime!

--- a/src/msha/server.ts
+++ b/src/msha/server.ts
@@ -1,3 +1,4 @@
+import open from "open";
 import chalk from "chalk";
 import fs from "fs";
 import http from "http";
@@ -23,6 +24,7 @@ import {
   SWA_CLI_ROUTES_LOCATION,
   SWA_WORKFLOW_CONFIG_FILE,
   SWA_CLI_DEVSERVER_TIMEOUT,
+  SWA_CLI_OPEN,
 } from "../core/constants";
 import { validateFunctionTriggers } from "./handlers/function.handler";
 import { handleUserConfig, onConnectionLost, requestMiddleware } from "./middlewares/request.middleware";
@@ -118,12 +120,15 @@ function onServerStart(server: https.Server | http.Server, socketConnection: net
     // note: this string must not change. It is used by the VS Code extension.
     // see: https://github.com/Azure/static-web-apps-cli/issues/124
     //--------------------------------------------------------------------------------
-    let logMessage = `\nAzure Static Web Apps emulator started at ${chalk.green(
-      address(SWA_CLI_HOST, SWA_CLI_PORT, SWA_CLI_APP_PROTOCOL)
-    )}. Press CTRL+C to exit.\n\n`;
+    const serverAddress = address(SWA_CLI_HOST, SWA_CLI_PORT, SWA_CLI_APP_PROTOCOL);
+    let logMessage = `\nAzure Static Web Apps emulator started at ${chalk.green(serverAddress)}. Press CTRL+C to exit.\n\n`;
     //--------------------------------------------------------------------------------
 
     logger.log(logMessage);
+
+    if (SWA_CLI_OPEN) {
+      open(serverAddress);
+    }
 
     server.on("upgrade", onWsUpgrade());
 

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -77,6 +77,7 @@ declare type SWACLIOptions = {
   overridableErrorCode?: number[];
   devserverTimeout?: number;
   funcArgs?: string;
+  open?: boolean;
 };
 
 declare type SWACLIConfig = SWACLIOptions & GithubActionWorkflow;


### PR DESCRIPTION
Note that the default behavior remains unchanged.
Adding `--open` will automatically open the SWA server in the default browser.