### PR TITLE
feat(auth): include claims in client principal data retrieved via direct-access endpoint

### DIFF
--- a/src/msha/handlers/function.handler.ts
+++ b/src/msha/handlers/function.handler.ts
@@ -31,6 +31,13 @@ function injectClientPrincipalCookies(req: http.ClientRequest) {
   const cookie = req.getHeader("cookie") as string;
   if (cookie && validateCookie(cookie)) {
     const user = decodeCookie(cookie);
+
+    // Remove claims from client principal to match SWA behaviour. See https://github.com/MicrosoftDocs/azure-docs/issues/86803.
+    // The following property deletion can be removed depending on outcome of the above issue.
+    if (user) {
+      delete user["claims"];
+    }
+
     const buff = Buffer.from(JSON.stringify(user), "utf-8");
     const token = buff.toString("base64");
     req.setHeader("X-MS-CLIENT-PRINCIPAL", token);

--- a/src/public/auth.html
+++ b/src/public/auth.html
@@ -55,7 +55,12 @@
           <div class="text-center"><img src=https://appservice.azureedge.net/images/static-apps/v3/staticapps.svg /></div>
         </div>
         <div
-          class="extra-pl-small-scr offset-xl-1 offset-lg-1 offset-md-2 offset-sm-2 offset-xs-4 col-xl-5 col-lg-5 col-md-10 col-sm-11 col-xs-11 div-vertical-center"
+          class="
+            extra-pl-small-scr
+            offset-xl-1 offset-lg-1 offset-md-2 offset-sm-2 offset-xs-4
+            col-xl-5 col-lg-5 col-md-10 col-sm-11 col-xs-11
+            div-vertical-center
+          "
         >
           <div class="container-fluid">
             <h1 class="pb-4">Azure Static Web Apps Auth</h1>
@@ -122,10 +127,21 @@
               <div class="form-group row">
                 <label for="userRoles" class="col-4 col-form-label">User’s roles</label>
                 <div class="col-8">
-                  <textarea id="userRoles" name="userRoles" cols="40" rows="5" class="form-control" aria-describedby="userRolesHelpBlock"></textarea>
+                  <textarea id="userRoles" name="userRoles" cols="40" rows="3" class="form-control" aria-describedby="userRolesHelpBlock"></textarea>
                   <small id="userRolesHelpBlock" class="form-text text-muted">Roles used during authorization. One role per line.</small>
                   <small id="userRolesHelpBlock" class="form-text text-muted"
                     >Note: roles "authenticated" and "anonymous" will be added automatically if not provided.</small
+                  >
+                </div>
+              </div>
+
+              <div class="form-group row">
+                <label for="claims" class="col-4 col-form-label">User’s claims</label>
+                <div class="col-8">
+                  <textarea id="claims" name="claims" cols="40" rows="3" class="form-control" aria-describedby="userClaimsHelpBlock"></textarea>
+                  <small id="userClaimsHelpBlock" class="form-text text-muted"
+                    >Claims from the identity provider. JSON array of claims. See
+                    <a href="https://docs.microsoft.com/en-gb/azure/static-web-apps/user-information">documentation</a> for example claims.</small
                   >
                 </div>
               </div>
@@ -232,6 +248,8 @@
           if (inputName === "userRoles") {
             // ensure default roles are included
             data[inputName] = [...new Set([...inputValue.trim().split("\n"), ...defaultRoles])];
+          } else if (inputName === "claims") {
+            data[inputName] = JSON.parse(inputValue);
           } else {
             data[inputName] = inputValue;
           }
@@ -278,6 +296,14 @@
               const userId = data[inputName] || generateUserId();
               input.val(userId);
               input.saveToLocalStorage();
+            } else if (inputName === "claims") {
+              if (Array.isArray(data[inputName])) {
+                input.val(JSON.stringify(data[inputName], null, 2));
+              } else if (input.val() === "") {
+                // set default values and cache entry
+                input.val("[]");
+                input.saveToLocalStorage();
+              }
             } else if (input.attr("type") !== "submit") {
               const value = data[inputName];
               input.val(value);

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -89,6 +89,7 @@ declare type ClientPrincipal = {
   userId: string;
   userDetails: string;
   userRoles: string[];
+  claims?: Array<{ typ: string; val: string }>;
 };
 
 declare type SWAConfigFileRoute = {


### PR DESCRIPTION

SWA documentation describes the client principal data retrievable by applications and
includes reference to claims returned by a custom authentication provider.

Change auth.html to capture mock claims information and store in the StaticWebAppsAuthCookie.

Change function.handler.ts to explicitly remove claims from the client principal data
encoded in the x-ms-client-principal header passed to proxied functions, matching current
SWA runtime behaviour.