### PR TITLE
fix: ignore invalid workflow files

### DIFF
--- a/cypress/fixtures/blazor-starter/swa-cli.config.json
+++ b/cypress/fixtures/blazor-starter/swa-cli.config.json
@@ -3,6 +3,7 @@
   "configurations": {
     "app": {
       "context": "http://localhost:5000",
+      "appLocation": "./cypress/fixtures/blazor-starter",
       "apiLocation": "./cypress/fixtures/blazor-starter/Api",
       "run": "dotnet run --project ./cypress/fixtures/blazor-starter/Client",
       "port": 1234,

--- a/cypress/fixtures/static/.github/workflows/azure-static-web-apps-NON-CONFORM.yml
+++ b/cypress/fixtures/static/.github/workflows/azure-static-web-apps-NON-CONFORM.yml
@@ -1,0 +1,27 @@
+name: Azure Static Web Apps CI/CD
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - "wrapperapp/**"
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+    - main
+    paths:
+    - "wrapperapp/**"
+
+jobs:
+  call_aswa_flow:
+    uses: devrel-kr/integration-villain/.github/workflows/build-aswa.yaml@main
+    with:
+      event_name: ${{ github.event_name }}
+      event_action: ${{ github.event.action }}
+      app_location: "wrapperapp/Wrapper.WasmApp"
+      api_location: "wrapperapp/Wrapper.ApiApp"
+      output_location: "wwwroot"
+    secrets:
+      gha_token: ${{ secrets.GITHUB_TOKEN }}
+      aswa_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_KIND_GRASS_02A5C181E }}

--- a/cypress/fixtures/static/swa-cli.config.json
+++ b/cypress/fixtures/static/swa-cli.config.json
@@ -2,6 +2,7 @@
   "$schema": "../../../schema/swa-cli.config.schema.json",
   "configurations": {
     "app": {
+      "appLocation": "./cypress/fixtures/static",
       "context": "./cypress/fixtures/static/app",
       "apiLocation": "./cypress/fixtures/static/api",
       "port": 1234,

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -81,9 +81,18 @@ export async function start(startContext: string, options: SWACLIConfig) {
   // mix CLI args with the project's build workflow configuration (if any)
   // use any specific workflow config that the user might provide undef ".github/workflows/"
   // Note: CLI args will take precedence over workflow config
-  userWorkflowConfig = readWorkflowFile({
-    userWorkflowConfig,
-  });
+  try {
+    userWorkflowConfig = readWorkflowFile({
+      userWorkflowConfig,
+    });
+  } catch (err) {
+    logger.warn(`Error reading workflow configuration:`);
+    logger.warn((err as any).message);
+    logger.warn(``);
+    logger.warn(
+      `See https://docs.microsoft.com/azure/static-web-apps/build-configuration?tabs=github-actions#build-configuration for more information.`
+    );
+  }
 
   const isApiLocationExistsOnDisk = fs.existsSync(userWorkflowConfig?.apiLocation!);
 

--- a/src/core/utils/workflow-config.ts
+++ b/src/core/utils/workflow-config.ts
@@ -26,7 +26,7 @@ export function readWorkflowFile({ userWorkflowConfig }: { userWorkflowConfig?: 
     }
   }
 
-  const githubActionFolder = path.resolve(process.cwd(), ".github/workflows/");
+  const githubActionFolder = path.resolve(userWorkflowConfig?.appLocation || process.cwd(), ".github/workflows/");
 
   // does the config folder exist?
   if (fs.existsSync(githubActionFolder) === false) {

--- a/src/msha/middlewares/request.middleware.ts
+++ b/src/msha/middlewares/request.middleware.ts
@@ -44,7 +44,7 @@ export function onConnectionLost(req: http.IncomingMessage, res: http.ServerResp
  * @param appLocation The location of the application code, where the application configuration file is located.
  * @returns The JSON content of the application configuration file defined in the `staticwebapp.config.json` file (or legacy file `routes.json`).
  * If no configuration file is found, returns `undefined`.
- * @see https://docs.microsoft.com/en-us/azure/static-web-apps/configuration
+ * @see https://docs.microsoft.com/azure/static-web-apps/configuration
  */
 export async function handleUserConfig(appLocation: string): Promise<SWAConfigFile | undefined> {
   if (!fs.existsSync(appLocation)) {
@@ -73,7 +73,7 @@ export async function handleUserConfig(appLocation: string): Promise<SWAConfigFi
     return configJson;
   } catch (error) {
     logger.silly(`${chalk.red("configuration file is invalid!")}`);
-    logger.silly(`${chalk.red(error.toString())}`);
+    logger.silly(`${chalk.red((error as any).toString())}`);
   }
 
   return configJson;

--- a/src/msha/routes-engine/rules/headers.ts
+++ b/src/msha/routes-engine/rules/headers.ts
@@ -3,7 +3,7 @@ import { logger } from "../../../core";
 
 import { CACHE_CONTROL_MAX_AGE, HEADER_DELETE_KEYWORD } from "../../../core/constants";
 
-// // See: https://docs.microsoft.com/en-us/azure/static-web-apps/configuration#global-headers
+// // See: https://docs.microsoft.com/azure/static-web-apps/configuration#global-headers
 
 export function updateResponseHeaders(res: http.ServerResponse, matchingRouteHeaders: SWAConfigFileRouteHeaders) {
   const headers = getResponseHeaders(matchingRouteHeaders);

--- a/src/msha/routes-engine/rules/mime-types.ts
+++ b/src/msha/routes-engine/rules/mime-types.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { logger } from "../../../core";
 import { DEFAULT_MIME_TYPE, MIME_TYPE_LIST } from "../../../core/constants";
 
-// See: https://docs.microsoft.com/en-us/azure/static-web-apps/configuration
+// See: https://docs.microsoft.com/azure/static-web-apps/configuration
 export async function mimeTypes(req: http.IncomingMessage, res: http.ServerResponse, mimeTypes: SWAConfigFileMimeTypes) {
   if (req.url?.includes(".")) {
     logger.silly(`checking mimeTypes rule`);

--- a/src/msha/routes-engine/rules/navigation-fallback.ts
+++ b/src/msha/routes-engine/rules/navigation-fallback.ts
@@ -8,7 +8,7 @@ import { AUTH_STATUS } from "../../../core/constants";
 import { doesRequestPathMatchRoute } from "../route-processor";
 import { getIndexHtml } from "./routes";
 
-// See: https://docs.microsoft.com/en-us/azure/static-web-apps/configuration#fallback-routes
+// See: https://docs.microsoft.com/azure/static-web-apps/configuration#fallback-routes
 
 export function navigationFallback(req: http.IncomingMessage, res: http.ServerResponse, navigationFallback: SWAConfigFileNavigationFallback) {
   let originlUrl = req.url;

--- a/src/msha/routes-engine/rules/response-overrides.ts
+++ b/src/msha/routes-engine/rules/response-overrides.ts
@@ -7,7 +7,7 @@ function tryGetResponseOverrideForStatusCode(responseOverrides: SWAConfigFileRes
   return responseOverrides?.[statusCode];
 }
 
-// See: https://docs.microsoft.com/en-us/azure/static-web-apps/configuration#response-overrides
+// See: https://docs.microsoft.com/azure/static-web-apps/configuration#response-overrides
 export function responseOverrides(req: http.IncomingMessage, res: http.ServerResponse, responseOverrides: SWAConfigFileResponseOverrides) {
   const statusCode = res.statusCode;
 

--- a/src/public/auth.html
+++ b/src/public/auth.html
@@ -150,7 +150,7 @@
                   <small id="userClaimsHelpBlockError" class="d-none form-text text-muted alert alert-danger">Invalid JSON value!</small>
                   <small id="userClaimsHelpBlock" class="form-text text-muted"
                     >Claims from the identity provider. JSON array of claims. See
-                    <a href="https://docs.microsoft.com/en-gb/azure/static-web-apps/user-information">documentation</a> for example claims.</small
+                    <a href="https://docs.microsoft.com/azure/static-web-apps/user-information">documentation</a> for example claims.</small
                   >
                 </div>
               </div>


### PR DESCRIPTION
Closes #363 

## Context:
We scan for GitHub Action workflow files (if present) in order to extract the build configuration. The way we validate the workflow file is based on the default templates that SWA generates when creating a new project. 

Initially, we threw an exception if the workflow file is not valid. With the new fix, we now simply show a warning and keep going.