### PR TITLE
chore: exclude unneeded files from package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,5 @@
 src
 scripts
 cypress*
+*.spec.*
+/docs

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.8.4-alpha",
   "description": "Azure Static Web Apps CLI",
   "scripts": {
-    "pretest": "npm run build",
     "test": "jest --detectOpenHandles --silent --verbose",
     "e2e:start:static": "npm run build && node ./dist/cli/bin.js --config ./cypress/fixtures/static/swa-cli.config.json start app",
     "e2e:start:blazor": "npm run build && node ./dist/cli/bin.js --config ./cypress/fixtures/blazor-starter/swa-cli.config.json start app",


### PR DESCRIPTION
This PR does 2 things:
- It removes the unneeded "pretest" script for building, as jest compiles TS files itself (faster test loop)
- It excludes spec files and pngs from the final package, reducing its download size by 283% (!)

Before:
![Screenshot 2022-03-24 at 21 09 21](https://user-images.githubusercontent.com/593151/160002930-8a30b770-13d0-4856-9187-1311d37362bb.png)
After:
![Screenshot 2022-03-24 at 21 09 02](https://user-images.githubusercontent.com/593151/160002949-eed3ca73-a408-4b52-84bb-39c035fcc69a.png)

