### PR TITLE
chore(cli): update json schema (closes #422)

### DIFF
--- a/schema/swa-cli.config.schema.json
+++ b/schema/swa-cli.config.schema.json
@@ -8,13 +8,13 @@
             "$ref": "#/$defs/globalParameters"
           },
           {
-            "$ref": "#/$defs/workflowParameters"
-          },
-          {
             "$ref": "#/$defs/startCommandParameters"
           },
           {
             "$ref": "#/$defs/loginCommandParameters"
+          },
+          {
+            "$ref": "#/$defs/loginSharedCommandParameters"
           },
           {
             "$ref": "#/$defs/initCommandParameters"
@@ -36,6 +36,9 @@
                     "$ref": "#/$defs/loginCommandParameters"
                   },
                   {
+                    "$ref": "#/$defs/loginSharedCommandParameters"
+                  },
+                  {
                     "$ref": "#/$defs/contextParameters"
                   }
                 ]
@@ -48,9 +51,6 @@
                 "allOf": [
                   {
                     "$ref": "#/$defs/globalParameters"
-                  },
-                  {
-                    "$ref": "#/$defs/workflowParameters"
                   },
                   {
                     "$ref": "#/$defs/startCommandParameters"
@@ -87,7 +87,7 @@
                     "$ref": "#/$defs/globalParameters"
                   },
                   {
-                    "$ref": "#/$defs/workflowParameters"
+                    "$ref": "#/$defs/loginSharedCommandParameters"
                   },
                   {
                     "$ref": "#/$defs/deployCommandParameters"
@@ -119,60 +119,32 @@
           "description": "Enable verbose output. Values are: silly,info,log,silent",
           "type": "string"
         },
+        "config": {
+          "description": "Path to swa-cli.config.json file to use",
+          "type": "string",
+          "not": {}
+        },
+        "printConfig": {
+          "description": "Print all resolved options",
+          "type": "string"
+        },
         "swaConfigLocation": {
-          "description": "The the directory where the staticwebapp.config.json file is located",
+          "description": "The directory where the staticwebapp.config.json file is located",
           "type": "string"
-        },
-        "subscription": {
-          "description": "Azure subscription ID used by this project",
-          "type": "string"
-        },
-        "resourceGroup": {
-          "description": "Azure resource group used by this project",
-          "type": "string"
-        },
-        "tenant": {
-          "description": "Azure tenant ID",
-          "type": "string"
-        },
-        "appName": {
-          "description": "Azure Static Web App application name",
-          "type": "string"
-        },
-        "clientId": {
-          "description": "Azure client ID",
-          "type": "string"
-        },
-        "clientSecret": {
-          "description": "Azure client secret",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "workflowParameters": {
-      "properties": {
-        "apiLocation": {
-          "description": "The folder containing the source code of the API application",
-          "type": "string"
-        },
-        "appLocation": {
-          "description": "The folder containing the source code of the front-end application",
-          "type": "string"
-        },
-        "outputLocation": {
-          "description": "The folder where the front-end public files are location",
-          "type": "string"
-        },
-        "build": {
-          "description": "Build the front-end app and API before starting the emulator",
-          "type": "boolean"
         }
       },
       "type": "object"
     },
     "startCommandParameters": {
       "properties": {
+        "appLocation": {
+          "description": "The folder containing the source code of the front-end application",
+          "type": "string"
+        },
+        "apiLocation": {
+          "description": "The folder containing the source code of the API application",
+          "type": "string"
+        },
         "apiPort": {
           "description": "The API server port passed to func start",
           "type": "number"
@@ -208,6 +180,39 @@
         "sslKey": {
           "description": "The SSL key (.key) to use when enabling HTTPS",
           "type": "string"
+        },
+        "funcArgs": {
+          "description": "Pass additional arguments to the func start command",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "loginSharedCommandParameters": {
+      "properties": {
+        "subscription": {
+          "description": "Azure subscription ID used by this project",
+          "type": "string"
+        },
+        "resourceGroup": {
+          "description": "Azure resource group used by this project",
+          "type": "string"
+        },
+        "appName": {
+          "description": "Azure Static Web App application name",
+          "type": "string"
+        },
+        "tenant": {
+          "description": "Azure tenant ID",
+          "type": "string"
+        },
+        "clientId": {
+          "description": "Azure client ID",
+          "type": "string"
+        },
+        "clientSecret": {
+          "description": "Azure client secret",
+          "type": "string"
         }
       },
       "type": "object"
@@ -223,8 +228,16 @@
     },
     "deployCommandParameters": {
       "properties": {
+        "apiLocation": {
+          "description": "The folder containing the source code of the API application",
+          "type": "string"
+        },
+        "outputLocation": {
+          "description": "The folder where the front-end public files are location",
+          "type": "string"
+        },
         "deploymentToken": {
-          "description": "The secret toekn used to authenticate with the Static Web Apps",
+          "description": "The secret token used to authenticate with the Static Web Apps",
           "not": {}
         },
         "dryRun": {

--- a/schema/swa-cli.config.schema.json
+++ b/schema/swa-cli.config.schema.json
@@ -1,116 +1,245 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft-07/schema",
   "properties": {
     "configurations": {
       "additionalProperties": {
         "allOf": [
           {
-            "properties": {
-              "apiLocation": {
-                "description": "The folder containing the source code of the API application",
-                "type": "string"
-              },
-              "outputLocation": {
-                "description": "The folder where the front-end public files are location",
-                "type": "string"
-              },
-              "deploymentToken": {
-                "description": "The secret toekn used to authenticate with the Static Web Apps",
-                "type": "string"
-              },
-              "dryRun": {
-                "description": "Simulate a deploy process without actually running it",
-                "type": "boolean"
-              },
-              "apiPort": {
-                "description": "The API server port passed to func start",
-                "type": "number"
-              },
-              "apiPrefix": {
-                "enum": ["api"],
-                "type": "string"
-              },
-              "appArtifactLocation": {
-                "description": "Location of the build output directory relative to the appLocation",
-                "type": "string"
-              },
-              "appLocation": {
-                "description": "The folder containing the source code of the front-end application",
-                "type": "string"
-              },
-              "build": {
-                "description": "Build the front-end app and API before starting the emulator",
-                "type": "boolean"
-              },
-              "open": {
-                "description": "Automatically open the CLI dev server in the default browser",
-                "type": "boolean"
-              },
-              "customUrlScheme": {
-                "type": "string"
-              },
-              "devserverTimeout": {
-                "description": "The time to wait (in ms) when connecting to a front-end application's dev server",
-                "type": "number"
-              },
-              "host": {
-                "description": "The host address to use for the CLI dev server",
-                "type": "string"
-              },
-              "overridableErrorCode": {
-                "items": {
-                  "type": "number"
-                },
-                "type": "array"
-              },
-              "port": {
-                "description": "The port value to use for the CLI dev server",
-                "type": "number"
-              },
-              "run": {
-                "description": "Run a custon shell command or file at startup",
-                "type": "string"
-              },
-              "ssl": {
-                "description": "Serve the front-end application and API over HTTPS",
-                "type": "boolean"
-              },
-              "sslCert": {
-                "description": "The SSL certificate (.crt) to use when enabling HTTPS",
-                "type": "string"
-              },
-              "sslKey": {
-                "description": "The SSL key (.key) to use when enabling HTTPS",
-                "type": "string"
-              },
-              "swaConfigFilename": {
-                "enum": ["staticwebapp.config.json"],
-                "type": "string"
-              },
-              "swaConfigFilenameLegacy": {
-                "enum": ["routes.json"],
-                "type": "string"
-              },
-              "swaConfigLocation": {
-                "description": "The the directory where the staticwebapp.config.json file is located",
-                "type": "string"
-              },
-              "verbose": {
-                "description": "Enable verbose output. Values are: silly,info,log,silent",
-                "type": "string"
-              }
-            },
-            "type": "object"
+            "$ref": "#/$defs/globalParameters"
+          },
+          {
+            "$ref": "#/$defs/workflowParameters"
+          },
+          {
+            "$ref": "#/$defs/startCommandParameters"
+          },
+          {
+            "$ref": "#/$defs/loginCommandParameters"
+          },
+          {
+            "$ref": "#/$defs/initCommandParameters"
+          },
+          {
+            "$ref": "#/$defs/deployCommandParameters"
+          },
+          {
+            "$ref": "#/$defs/contextParameters"
           },
           {
             "properties": {
-              "context": {
-                "type": "string"
+              "login": {
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/globalParameters"
+                  },
+                  {
+                    "$ref": "#/$defs/loginCommandParameters"
+                  },
+                  {
+                    "$ref": "#/$defs/contextParameters"
+                  }
+                ]
               }
-            },
-            "type": "object"
+            }
+          },
+          {
+            "properties": {
+              "start": {
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/globalParameters"
+                  },
+                  {
+                    "$ref": "#/$defs/workflowParameters"
+                  },
+                  {
+                    "$ref": "#/$defs/startCommandParameters"
+                  },
+                  {
+                    "$ref": "#/$defs/contextParameters"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "init": {
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/globalParameters"
+                  },
+                  {
+                    "$ref": "#/$defs/initCommandParameters"
+                  },
+                  {
+                    "$ref": "#/$defs/contextParameters"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "deploy": {
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/globalParameters"
+                  },
+                  {
+                    "$ref": "#/$defs/workflowParameters"
+                  },
+                  {
+                    "$ref": "#/$defs/deployCommandParameters"
+                  },
+                  {
+                    "$ref": "#/$defs/contextParameters"
+                  }
+                ]
+              }
+            }
           }
         ]
+      },
+      "type": "object"
+    }
+  },
+  "$defs": {
+    "contextParameters": {
+      "properties": {
+        "context": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "globalParameters": {
+      "properties": {
+        "verbose": {
+          "description": "Enable verbose output. Values are: silly,info,log,silent",
+          "type": "string"
+        },
+        "swaConfigLocation": {
+          "description": "The the directory where the staticwebapp.config.json file is located",
+          "type": "string"
+        },
+        "subscription": {
+          "description": "Azure subscription ID used by this project",
+          "type": "string"
+        },
+        "resourceGroup": {
+          "description": "Azure resource group used by this project",
+          "type": "string"
+        },
+        "tenant": {
+          "description": "Azure tenant ID",
+          "type": "string"
+        },
+        "appName": {
+          "description": "Azure Static Web App application name",
+          "type": "string"
+        },
+        "clientId": {
+          "description": "Azure client ID",
+          "type": "string"
+        },
+        "clientSecret": {
+          "description": "Azure client secret",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "workflowParameters": {
+      "properties": {
+        "apiLocation": {
+          "description": "The folder containing the source code of the API application",
+          "type": "string"
+        },
+        "appLocation": {
+          "description": "The folder containing the source code of the front-end application",
+          "type": "string"
+        },
+        "outputLocation": {
+          "description": "The folder where the front-end public files are location",
+          "type": "string"
+        },
+        "build": {
+          "description": "Build the front-end app and API before starting the emulator",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "startCommandParameters": {
+      "properties": {
+        "apiPort": {
+          "description": "The API server port passed to func start",
+          "type": "number"
+        },
+        "open": {
+          "description": "Automatically open the CLI dev server in the default browser",
+          "type": "boolean"
+        },
+        "devserverTimeout": {
+          "description": "The time to wait (in ms) when connecting to a front-end application's dev server",
+          "type": "number"
+        },
+        "host": {
+          "description": "The host address to use for the CLI dev server",
+          "type": "string"
+        },
+        "port": {
+          "description": "The port value to use for the CLI dev server",
+          "type": "number"
+        },
+        "run": {
+          "description": "Run a custon shell command or file at startup",
+          "type": "string"
+        },
+        "ssl": {
+          "description": "Serve the front-end application and API over HTTPS",
+          "type": "boolean"
+        },
+        "sslCert": {
+          "description": "The SSL certificate (.crt) to use when enabling HTTPS",
+          "type": "string"
+        },
+        "sslKey": {
+          "description": "The SSL key (.key) to use when enabling HTTPS",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "loginCommandParameters": {
+      "properties": {
+        "persist": {
+          "description": "Enable credentials cache persistence",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "deployCommandParameters": {
+      "properties": {
+        "deploymentToken": {
+          "description": "The secret toekn used to authenticate with the Static Web Apps",
+          "not": {}
+        },
+        "dryRun": {
+          "description": "Simulate a deploy process without actually running it",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "initCommandParameters": {
+      "properties": {
+        "yes": {
+          "description": "Answer yes to all prompts (disable interactive mode)",
+          "type": "boolean"
+        }
       },
       "type": "object"
     }

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -9,12 +9,12 @@ import { configureOptions, findSWAConfigFile, logger, readWorkflowFile } from ".
 import { getStaticSiteDeployment } from "../../core/account";
 import { cleanUp, getDeployClientPath } from "../../core/deploy-client";
 import { swaCLIEnv } from "../../core/env";
-import { login } from "./login";
+import { login, addSharedLoginOptionsToCommand } from "./login";
 
 const packageInfo = require(path.join(__dirname, "..", "..", "..", "package.json"));
 
 export default function registerCommand(program: Command) {
-  program
+  const deployCommand = program
     .command("deploy [context]")
     .usage("[context] [options]")
     .description("Deploy the current project to Azure Static Web Apps")
@@ -41,6 +41,7 @@ Examples:
   swa deploy myconfig
     `
     );
+  addSharedLoginOptionsToCommand(deployCommand);
 }
 
 export async function deploy(deployContext: string, options: SWACLIConfig) {

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -9,8 +9,18 @@ import { azureLoginWithIdentitySDK, listResourceGroups, listStaticSites, listSub
 import { chooseResourceGroup, chooseStaticSite, chooseSubscription, chooseTenant } from "../../core/prompts";
 import { Environment } from "../../core/swa-cli-persistence-plugin/impl/azure-environment";
 
+export function addSharedLoginOptionsToCommand(command: Command) {
+  command
+    .option("--subscription [subscriptionId]", "Azure subscription ID used by this project", DEFAULT_CONFIG.subscriptionId)
+    .option("--resource-group [resourceGroup]", "Azure resource group used by this project", DEFAULT_CONFIG.resourceGroupName)
+    .option("--tenant [tenantId]", "Azure tenant ID", DEFAULT_CONFIG.tenantId)
+    .option("--client-id [clientId]", "Azure client ID", DEFAULT_CONFIG.clientId)
+    .option("--client-secret [clientSecret]", "Azure client secret", DEFAULT_CONFIG.clientSecret)
+    .option("--app-name [appName]", "Azure Static Web App application name", DEFAULT_CONFIG.appName);
+}
+
 export default function registerCommand(program: Command) {
-  program
+  const loginCommand = program
     .command("login")
     .usage("[options]")
     .description("login into Azure Static Web Apps")
@@ -38,6 +48,7 @@ Examples:
             --client-secret 0000000000000000000000000000000000000000000000000000000000000000
     `
     );
+  addSharedLoginOptionsToCommand(loginCommand);
 }
 
 export async function login(options: SWACLIConfig) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -39,8 +39,6 @@ export async function run(argv?: string[]) {
         .preset(DEFAULT_CONFIG.verbose)
         .default(DEFAULT_CONFIG.verbose)
     )
-    .addHelpText("after", "\nDocumentation:\n  https://aka.ms/swa/cli-local-development\n")
-
     .option("--config <path>", "path to swa-cli.config.json file to use", path.relative(process.cwd(), swaCliConfigFilename))
     .option("--print-config", "print all resolved options", false)
     .option(

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,18 +30,11 @@ export const DEFAULT_CONFIG: SWACLIConfig = {
   sslKey: SWA_CLI_APP_SSL_KEY || undefined,
   appBuildCommand: "npm run build --if-present",
   apiBuildCommand: "npm run build --if-present",
-  swaConfigFilename: "staticwebapp.config.json",
-  swaConfigFilenameLegacy: "routes.json",
   run: undefined,
   verbose: "log",
   devserverTimeout: parseInt(SWA_CLI_DEVSERVER_TIMEOUT || "30000", 10),
   open: SWA_CLI_OPEN_BROWSER === "true" || false,
   githubActionWorkflowLocation: SWA_RUNTIME_WORKFLOW_LOCATION || undefined,
-
-  // @internal
-  overridableErrorCode: [400, 401, 403, 404],
-  customUrlScheme: "swa://",
-  apiPrefix: "api",
 
   // swa login options
   persist: true,
@@ -52,4 +45,12 @@ export const DEFAULT_CONFIG: SWACLIConfig = {
   clientSecret: undefined,
   appName: undefined,
   dryRun: false,
+
+  // TODO: these are constants, not configurable
+  // they should be moved out of the config
+  apiPrefix: "api",
+  swaConfigFilename: "staticwebapp.config.json",
+  swaConfigFilenameLegacy: "routes.json",
+  customUrlScheme: "swa://",
+  overridableErrorCode: [400, 401, 403, 404],
 };

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -112,6 +112,7 @@ declare type SWACLIGlobalOptions = {
   config?: string;
   printConfig?: boolean;
   swaConfigLocation?: string;
+  githubActionWorkflowLocation?: string;
 };
 
 // -- CLI Init options -------------------------------------------------------
@@ -180,8 +181,7 @@ declare type SWACLIContextOptions = {
 
 // -- CLI Login options ------------------------------------------------------
 
-declare type SWACLIConfig =
-  SWACLIOptionsToCleanUp &
+declare type SWACLIConfig = SWACLIOptionsToCleanUp &
   SWACLIGlobalOptions &
   SWACLILoginOptions &
   SWACLIInitOptions &
@@ -189,12 +189,11 @@ declare type SWACLIConfig =
   SWACLIStartOptions &
   SWACLIDeployOptions &
   SWACLIContextOptions & {
-
-  login?: SWACLIGlobalOptions & SWACLILoginOptions & SWACLIContextOptions,
-  init?: SWACLIGlobalOptions & SWACLIInitOptions & SWACLIContextOptions,
-  start?: SWACLIGlobalOptions & SWACLIStartOptions & SWACLIContextOptions,
-  deploy?: SWACLIGlobalOptions & SWACLIDeployOptions & SWACLIContextOptions
-};
+    login?: SWACLIGlobalOptions & SWACLILoginOptions & SWACLIContextOptions;
+    init?: SWACLIGlobalOptions & SWACLIInitOptions & SWACLIContextOptions;
+    start?: SWACLIGlobalOptions & SWACLIStartOptions & SWACLIContextOptions;
+    deploy?: SWACLIGlobalOptions & SWACLIDeployOptions & SWACLIContextOptions;
+  };
 
 declare type ResponseOptions = {
   [key: string]: any;

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -76,6 +76,7 @@ declare interface Path {
   method: "GET" | "POST";
 }
 
+// TODO: cleanup when we rework RuntimeHost
 declare type RuntimeHostConfig = {
   appPort: number;
   proxyHost: string;
@@ -93,54 +94,106 @@ declare type GithubActionWorkflow = {
   files?: string[];
 };
 
-declare type SWACLIStartOptions = {
-  port?: number;
-  host?: string;
-  apiPort?: number;
-  ssl?: boolean;
-  apiPrefix?: "api";
-  sslCert?: string;
-  sslKey?: string;
-  swaConfigFilename?: string;
-  swaConfigFilenameLegacy?: string;
-  app?: string;
-  apiLocation?: string;
+// -- CLI Global options -----------------------------------------------------
+
+declare type SWACLIOptionsToCleanUp = {
+  // TODO: cleanup
+  // app?: string;
   build?: boolean;
-  verbose?: string;
-  run?: string;
-  swaConfigLocation?: string;
   customUrlScheme?: string;
   overridableErrorCode?: number[];
-  devserverTimeout?: number;
-  funcArgs?: string;
-  open?: boolean;
-  config?: string;
-  printConfig?: boolean;
-  yes?: boolean;
-  githubActionWorkflowLocation?: string;
+  swaConfigFilename?: "staticwebapp.config.json";
+  swaConfigFilenameLegacy?: "routes.json";
+  apiPrefix?: "api";
 };
 
-declare type SWACLIDeployOptions = {
-  outputLocation?: string;
+declare type SWACLIGlobalOptions = {
+  verbose?: string;
+  config?: string;
+  printConfig?: boolean;
+  swaConfigLocation?: string;
+};
+
+// -- CLI Init options -------------------------------------------------------
+
+declare type SWACLIInitOptions = {
+  yes?: boolean;
+};
+
+// -- CLI Start options ------------------------------------------------------
+
+declare type SWACLIStartOptions = {
+  appLocation?: string;
   apiLocation?: string;
+  apiPort?: number;
+  host?: string;
+  port?: number;
+  ssl?: boolean;
+  sslCert?: string;
+  sslKey?: string;
+  run?: string;
+  devserverTimeout?: number;
+  open?: boolean;
+  funcArgs?: string;
+};
+
+// -- CLI Build options ------------------------------------------------------
+
+// Note: build command does not exist at the moment
+declare type SWACLIBuildOptions = {
+  appBuildCommand?: string;
+  apiBuildCommand?: string;
+};
+
+// -- CLI Deploy options -----------------------------------------------------
+
+declare type SWACLIDeployOptions = SWACLISharedLoginOptions & {
+  apiLocation?: string;
+  outputLocation?: string;
   deploymentToken?: string;
   dryRun?: boolean;
 };
 
-declare type SWACLIConfig = SWACLIStartOptions & SWACLILoginOptions & SWACLIDeployOptions & GithubActionWorkflow;
+// -- CLI Login options ------------------------------------------------------
 
-declare type SWACLILoginOptions = LoginDetails & {
-  persist?: boolean;
+declare type LoginDetails = {
+  tenantId?: string;
+  clientId?: string;
+  clientSecret?: string;
+};
+
+declare type SWACLISharedLoginOptions = LoginDetails & {
   subscriptionId?: string;
   resourceGroupName?: string;
   appName?: string;
 };
 
-interface LoginDetails {
-  tenantId?: string;
-  clientId?: string;
-  clientSecret?: string;
-}
+declare type SWACLILoginOptions = SWACLISharedLoginOptions & {
+  persist?: boolean;
+};
+
+// -- CLI Context options ----------------------------------------------------
+
+declare type SWACLIContextOptions = {
+  context?: string;
+};
+
+// -- CLI Login options ------------------------------------------------------
+
+declare type SWACLIConfig =
+  SWACLIOptionsToCleanUp &
+  SWACLIGlobalOptions &
+  SWACLILoginOptions &
+  SWACLIInitOptions &
+  SWACLIBuildOptions &
+  SWACLIStartOptions &
+  SWACLIDeployOptions & {
+
+  login?: SWACLIGlobalOptions & SWACLILoginOptions,
+  init?: SWACLIGlobalOptions & SWACLIInitOptions,
+  start?: SWACLIGlobalOptions & SWACLIStartOptions,
+  deploy?: SWACLIGlobalOptions & SWACLIDeployOptions
+};
 
 declare type ResponseOptions = {
   [key: string]: any;

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -187,12 +187,13 @@ declare type SWACLIConfig =
   SWACLIInitOptions &
   SWACLIBuildOptions &
   SWACLIStartOptions &
-  SWACLIDeployOptions & {
+  SWACLIDeployOptions &
+  SWACLIContextOptions & {
 
-  login?: SWACLIGlobalOptions & SWACLILoginOptions,
-  init?: SWACLIGlobalOptions & SWACLIInitOptions,
-  start?: SWACLIGlobalOptions & SWACLIStartOptions,
-  deploy?: SWACLIGlobalOptions & SWACLIDeployOptions
+  login?: SWACLIGlobalOptions & SWACLILoginOptions & SWACLIContextOptions,
+  init?: SWACLIGlobalOptions & SWACLIInitOptions & SWACLIContextOptions,
+  start?: SWACLIGlobalOptions & SWACLIStartOptions & SWACLIContextOptions,
+  deploy?: SWACLIGlobalOptions & SWACLIDeployOptions & SWACLIContextOptions
 };
 
 declare type ResponseOptions = {
@@ -256,7 +257,7 @@ declare type DebugFilterLevel = "silly" | "silent" | "log" | "info" | "error";
 declare type SWACLIConfigFile = {
   $schema?: string;
   configurations?: {
-    [name: string]: SWACLIOptions & { context?: string };
+    [name: string]: SWACLIOptions;
   };
 };
 


### PR DESCRIPTION
Cleaned unused settings and constants from schema:
- appArtifactLocation
- build (superseded by appBuildCommand and apiBuildCommand)
- apiPrefix
- swaConfigFilename
- swaConfigFilenameLegacy
- customUrlScheme
- overridableErrorCode

We can't enforce proper schema exclusion for extra properties as we need to migrate to draft/2019-09 to be able to use `unevaluatedProperties` for that. But draft/2019-09 version isn't currently properly supported by VS Code, so it's not the good time to migrate.

I specifically enforced exclusion of `deploymentToken` from config file though.