### PR TITLE
feat(deploy): handle different case scenarios 

### DIFF
--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -23,6 +23,9 @@
 | SWA_CLI_DEPLOY_DRY_RUN        | Simulate a deploy process without actually running it (`true` or `false`)          |            | `false`       |
 | SWA_CLI_DEPLOY_BINARY_VERSION | Deployment binary version to use                                                   |            | `stable`      |
 | SWA_CLI_DEPLOY_BINARY         | Absoluate path to the deploy binary                                                | Yes        |               |
+| AZURE_REGION_LOCATION         | Azure region where to deploy the project                                           |            | `West US 2`   |
+| AZURE_RESOURCE_GROUP          | Azure resource group                                                               |            |               |
+| AZURE_SUBSCRIPTION_ID         | Azure subscription ID                                                              |            |               |
 | **Runtime settings**          |                                                                                    |            |               |
 | SWA_RUNTIME_CONFIG            | Absolute path to `staticwebapp.config.json`                                        |            |               |
 | SWA_RUNTIME_CONFIG_LOCATION   | Folder containing the file `staticwebapp.config.json`                              |            |               |
@@ -31,5 +34,3 @@
 | AZURE_CLIENT_ID               | Azure Active Directory client ID                                                   |            |               |
 | AZURE_CLIENT_SECRET           | Azure Active Directory secret                                                      |            |               |
 | AZURE_TENANT_ID               | Azure Active Directory tenant ID                                                   |            |               |
-| AZURE_SUBSCRIPTION_ID         | Azure subscription ID                                                              |            |               |
-| AZURE_RESOURCE_GROUP          | Azure resource group                                                               |            |               |

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -29,6 +29,7 @@ export default function registerCommand(program: Command) {
     .option("--api-location <apiLocation>", "the folder containing the source code of the API application", DEFAULT_CONFIG.apiLocation)
     .option("--deployment-token <secret>", "the secret token used to authenticate with the Static Web Apps")
     .option("--dry-run", "simulate a deploy process without actually running it", DEFAULT_CONFIG.dryRun)
+    .option("--print-token", "print the deployment token", false)
     .action(async (context: string = `.${path.sep}`, _options: SWACLIConfig, command: Command) => {
       const config = await configureOptions(context, command.optsWithGlobals(), command);
       await deploy(config.context ?? context, config.options);
@@ -47,6 +48,9 @@ Examples:
   Deploy using swa-cli.config.json file
   swa deploy
   swa deploy myconfig
+
+  Just print the deployment token
+  swa deploy --print-token
     `
     );
   addSharedLoginOptionsToCommand(deployCommand);
@@ -170,6 +174,12 @@ export async function deploy(deployContext: string, options: SWACLIConfig) {
     }
   }
   logger.log(``);
+
+  if (options.printToken) {
+    logger.log(`Deployment token:`);
+    logger.log(chalk.green(deploymentToken));
+    process.exit(0);
+  }
 
   let userWorkflowConfig: Partial<GithubActionWorkflow> | undefined = {
     appLocation: options.appLocation,

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -78,9 +78,8 @@ export async function deploy(deployContext: string, options: SWACLIConfig) {
     if (fs.existsSync(defaultApiFolder)) {
       logger.warn(
         `An API folder was found at ".${
-          path.sep + DEFAULT_CONFIG.apiPrefix!
-        }" but the --api-location option was not provided. API will not be deployed!`,
-        "swa"
+          path.sep + path.basename(defaultApiFolder)
+        }" but the --api-location option was not provided. The API will not be deployed.\n`
       );
     }
   }
@@ -103,7 +102,6 @@ export async function deploy(deployContext: string, options: SWACLIConfig) {
 
       const { credentialChain, subscriptionId } = await login({
         ...options,
-        useKeychain: true,
       });
 
       logger.silly(`Login successful`);
@@ -117,7 +115,12 @@ export async function deploy(deployContext: string, options: SWACLIConfig) {
         subscriptionId,
       });
 
-      const deploymentTokenResponse = await getStaticSiteDeployment(credentialChain, subscriptionId, resourceGroupName, staticSiteName);
+      const deploymentTokenResponse = await getStaticSiteDeployment(
+        credentialChain,
+        subscriptionId,
+        resourceGroupName as string,
+        staticSiteName as string
+      );
 
       deploymentToken = deploymentTokenResponse?.properties?.apiKey;
 
@@ -125,7 +128,7 @@ export async function deploy(deployContext: string, options: SWACLIConfig) {
         throw new Error("Cannot find a deployment token. Aborting.");
       }
 
-      logger.log("Deployment token provided via remote config");
+      logger.log("\nDeployment token provided via remote configuration");
       logger.log({ [chalk.green(`deploymentToken`)]: deploymentToken });
     } catch (error: any) {
       logger.error(error.message);
@@ -243,7 +246,8 @@ export async function deploy(deployContext: string, options: SWACLIConfig) {
         cleanUp();
 
         if (code === 0) {
-          spinner.succeed(chalk.green(`Deployed to ${projectUrl}`));
+          spinner.succeed(chalk.green(`Deployed to ${chalk.underline(projectUrl)} 🚀`));
+          logger.log(``);
         }
       });
     }

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -6,11 +6,11 @@ import process from "process";
 import { DEFAULT_CONFIG } from "../../config";
 import { promptOrUseDefault } from "../../core/prompts";
 import {
-  configExists,
   configureOptions,
   dasherize,
   hasConfigurationNameInConfigFile,
   logger,
+  swaCliConfigFileExists,
   swaCliConfigFilename,
   writeConfigFile,
 } from "../../core/utils";
@@ -74,7 +74,7 @@ export async function init(name: string | undefined, options: SWACLIConfig, show
   //   projectConfig = await promptConfigSettings(disablePrompts, projectConfig);
   // }
 
-  if (configExists(configFilePath) && (await hasConfigurationNameInConfigFile(configFilePath, projectName))) {
+  if (swaCliConfigFileExists(configFilePath) && (await hasConfigurationNameInConfigFile(configFilePath, projectName))) {
     const { confirmOverwrite } = await promptOrUseDefault(disablePrompts, {
       type: "confirm",
       name: "confirmOverwrite",

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,19 +1,19 @@
+import chalk from "chalk";
+import { Command } from "commander";
 import path from "path";
 // import fs from "fs";
 import process from "process";
-import prompts from "prompts";
-import chalk from "chalk";
-import { Command } from "commander";
+import { DEFAULT_CONFIG } from "../../config";
+import { promptOrUseDefault } from "../../core/prompts";
 import {
-  logger,
-  dasherize,
-  hasConfigurationNameInConfigFile,
-  writeConfigFile,
-  swaCliConfigFilename,
   configExists,
   configureOptions,
+  dasherize,
+  hasConfigurationNameInConfigFile,
+  logger,
+  swaCliConfigFilename,
+  writeConfigFile,
 } from "../../core/utils";
-import { DEFAULT_CONFIG } from "../../config";
 
 export default function registerCommand(program: Command) {
   program
@@ -74,7 +74,7 @@ export async function init(name: string | undefined, options: SWACLIConfig, show
   //   projectConfig = await promptConfigSettings(disablePrompts, projectConfig);
   // }
 
-  if (configExists(configFilePath) && await hasConfigurationNameInConfigFile(configFilePath, projectName)) {
+  if (configExists(configFilePath) && (await hasConfigurationNameInConfigFile(configFilePath, projectName))) {
     const { confirmOverwrite } = await promptOrUseDefault(disablePrompts, {
       type: "confirm",
       name: "confirmOverwrite",
@@ -111,7 +111,7 @@ function convertToCliConfig(config: FrameworkConfig): SWACLIConfig {
     },
     deploy: {
       context: config.outputLocation,
-    }
+    },
   };
 }
 
@@ -188,28 +188,6 @@ async function promptConfigSettings(disablePrompts: boolean, detectedConfig: Fra
 //   logger.log(`- Dev command: ${chalk.green(config.devServerCommand ?? '')}`);
 //   logger.log(`- Dev server URL: ${chalk.green(config.devServerUrl ?? '')}\n`);
 // }
-
-async function promptOrUseDefault<T extends string = string>(
-  disablePrompts: boolean,
-  questions: prompts.PromptObject<T> | Array<prompts.PromptObject<T>>,
-  options?: prompts.Options
-): Promise<prompts.Answers<T>> {
-  if (disablePrompts) {
-    const response = {} as prompts.Answers<T>;
-    questions = Array.isArray(questions) ? questions : [questions];
-    for (const question of questions) {
-      response[question.name as T] = question.initial;
-    }
-    return response;
-  }
-
-  return prompts(questions, { ...options, onCancel: cancelPrompt });
-}
-
-function cancelPrompt() {
-  logger.log("Aborted, configuration not saved.");
-  process.exit(-1);
-}
 
 // function isEmptyFolder(path: string) {
 //   const files = fs.readdirSync(path);

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -9,13 +9,12 @@ import { DEFAULT_CONFIG } from "../../config";
 import { configureOptions, logger, logGiHubIssueMessageAndExit } from "../../core";
 import { authenticateWithAzureIdentity, listSubscriptions, listTenants } from "../../core/account";
 import { ENV_FILENAME } from "../../core/constants";
-import { swaCLIEnv } from "../../core/env";
 import { updateGitIgnore } from "../../core/git";
 import { chooseSubscription, chooseTenant } from "../../core/prompts";
 
 export function addSharedLoginOptionsToCommand(command: Command) {
   command
-    .option("--subscription [subscriptionId]", "Azure subscription ID used by this project", DEFAULT_CONFIG.subscriptionId)
+    .option("--subscription-id [subscriptionId]", "Azure subscription ID used by this project", DEFAULT_CONFIG.subscriptionId)
     .option("--resource-group [resourceGroupName]", "Azure resource group used by this project", DEFAULT_CONFIG.resourceGroupName)
     .option("--tenant-id [tenantId]", "Azure tenant ID", DEFAULT_CONFIG.tenantId)
     .option("--client-id [clientId]", "Azure client ID", DEFAULT_CONFIG.clientId)
@@ -79,9 +78,9 @@ export async function login(options: SWACLIConfig) {
 
   logger.log(`Checking Azure session...`);
 
-  let tenantId: string | undefined = DEFAULT_CONFIG.tenantId;
-  let clientId: string | undefined = DEFAULT_CONFIG.clientId;
-  let clientSecret: string | undefined = DEFAULT_CONFIG.clientSecret;
+  let tenantId: string | undefined = options.tenantId;
+  let clientId: string | undefined = options.clientId;
+  let clientSecret: string | undefined = options.clientSecret;
 
   credentialChain = await authenticateWithAzureIdentity({ tenantId, clientId, clientSecret }, options.useKeychain);
 
@@ -94,14 +93,9 @@ export async function login(options: SWACLIConfig) {
 
 async function setupProjectCredentials(options: SWACLIConfig, credentialChain: TokenCredential) {
   logger.log(``);
-  logger.log(`Setting project...`);
+  logger.log(`Checking project settings...`);
 
-  const { AZURE_SUBSCRIPTION_ID, AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET } = swaCLIEnv();
-
-  let subscriptionId: string | undefined = AZURE_SUBSCRIPTION_ID ?? options.subscriptionId;
-  let tenantId: string | undefined = AZURE_TENANT_ID ?? options.tenantId;
-  let clientId: string | undefined = AZURE_CLIENT_ID ?? options.clientId;
-  let clientSecret: string | undefined = AZURE_CLIENT_SECRET ?? options.clientSecret;
+  let { subscriptionId, tenantId, clientId, clientSecret } = options;
 
   // If the user has not specified a tenantId, we will prompt them to choose one
   if (!tenantId) {
@@ -149,7 +143,7 @@ async function setupProjectCredentials(options: SWACLIConfig, credentialChain: T
 
   return {
     credentialChain,
-    subscriptionId,
+    subscriptionId: subscriptionId as string,
   };
 }
 

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -95,9 +95,6 @@ export async function login(options: SWACLIConfig) {
 }
 
 async function setupProjectCredentials(options: SWACLIConfig, credentialChain: TokenCredential) {
-  logger.log(``);
-  logger.log(`Checking project settings...`);
-
   let { subscriptionId, tenantId, clientId, clientSecret } = options;
 
   // If the user has not specified a tenantId, we will prompt them to choose one

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -19,7 +19,11 @@ export function addSharedLoginOptionsToCommand(command: Command) {
     .option("--tenant-id [tenantId]", "Azure tenant ID", DEFAULT_CONFIG.tenantId)
     .option("--client-id [clientId]", "Azure client ID", DEFAULT_CONFIG.clientId)
     .option("--client-secret [clientSecret]", "Azure client secret", DEFAULT_CONFIG.clientSecret)
-    .option("--app-name [appName]", "Azure Static Web App application name", DEFAULT_CONFIG.appName);
+    .option("--app-name [appName]", "Azure Static Web App application name", DEFAULT_CONFIG.appName)
+    .option("--use-keychain", "Enable using the operating system native keychain", DEFAULT_CONFIG.useKeychain)
+
+    // Note: Commander does not automatically recognize the --no-* option, so we have to explicitly use --no-use-keychain- instead
+    .option("--no-use-keychain", "Disable using the operating system native keychain", !DEFAULT_CONFIG.useKeychain);
 }
 
 export default function registerCommand(program: Command) {
@@ -27,7 +31,6 @@ export default function registerCommand(program: Command) {
     .command("login")
     .usage("[options]")
     .description("login into Azure Static Web Apps")
-    .option("--use-keychain", "Enable to use the operating system native keychain", DEFAULT_CONFIG.useKeychain)
     .action(async (_options: SWACLIConfig, command: Command) => {
       const config = await configureOptions(undefined, command.optsWithGlobals(), command);
 
@@ -54,7 +57,7 @@ Examples:
   swa login
 
   Interactive login without using the native keychain
-  swa login --useKeychain false
+  swa login --no-use-keychain
 
   Log in into specific tenant
   swa login --tenant-id 00000000-0000-0000-0000-000000000000
@@ -188,7 +191,7 @@ async function storeProjectCredentialsInEnvFile(
     const envFileContentWithProjectDetails = [...oldEnvFileLines, ...newEnvFileLines].join("\n");
     await writeFile(envFile, envFileContentWithProjectDetails);
 
-    logger.log(chalk.green(`✔ Successfully project credentials in ${ENV_FILENAME} file.`));
+    logger.log(chalk.green(`✔ Saved project credentials in ${ENV_FILENAME} file.`));
 
     await updateGitIgnore(ENV_FILENAME);
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,8 @@
+import dotenv from "dotenv";
+dotenv.config();
+
 import chalk from "chalk";
 import { Option, program } from "commander";
-import dotenv from "dotenv";
 import path from "path";
 import updateNotifier from "update-notifier";
 import { DEFAULT_CONFIG } from "../config";
@@ -9,7 +11,6 @@ import registerDeploy from "./commands/deploy";
 import registerInit from "./commands/init";
 import registerLogin from "./commands/login";
 import registerStart from "./commands/start";
-dotenv.config();
 
 export * from "./commands";
 
@@ -20,6 +21,9 @@ const printWelcomeMessage = () => {
   console.log(``);
   console.log(`Welcome to Azure Static Web Apps CLI (${chalk.green(pkg.version)})`);
   console.log(``);
+
+  console.log(`Default config:`);
+  console.table(DEFAULT_CONFIG);
 };
 
 export async function run(argv?: string[]) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,9 +21,6 @@ const printWelcomeMessage = () => {
   console.log(``);
   console.log(`Welcome to Azure Static Web Apps CLI (${chalk.green(pkg.version)})`);
   console.log(``);
-
-  console.log(`Default config:`);
-  console.table(DEFAULT_CONFIG);
 };
 
 export async function run(argv?: string[]) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,10 +33,10 @@ export const DEFAULT_CONFIG: SWACLIConfig = {
   port: parseInt(SWA_CLI_PORT || "4280", 10),
   host: SWA_CLI_HOST || "localhost",
   apiPort: parseInt(SWA_CLI_API_PORT || "7071", 10),
-  appLocation: path.resolve(SWA_CLI_APP_LOCATION || `.${path.sep}`),
-  apiLocation: SWA_CLI_API_LOCATION ? path.resolve(SWA_CLI_API_LOCATION) : undefined,
-  outputLocation: path.resolve(SWA_CLI_OUTPUT_LOCATION || `.${path.sep}`),
-  swaConfigLocation: path.resolve(SWA_RUNTIME_CONFIG_LOCATION || `.${path.sep}`),
+  appLocation: SWA_CLI_APP_LOCATION || `.${path.sep}`,
+  apiLocation: SWA_CLI_API_LOCATION ? SWA_CLI_API_LOCATION : undefined,
+  outputLocation: SWA_CLI_OUTPUT_LOCATION || `.${path.sep}`,
+  swaConfigLocation: SWA_RUNTIME_CONFIG_LOCATION || `.${path.sep}`,
   ssl: useEnvVarOrUseDefault(SWA_CLI_APP_SSL, false),
   sslCert: SWA_CLI_APP_SSL_CERT || undefined,
   sslKey: SWA_CLI_APP_SSL_KEY || undefined,
@@ -46,7 +46,7 @@ export const DEFAULT_CONFIG: SWACLIConfig = {
   verbose: SWA_CLI_DEBUG || "log",
   devserverTimeout: parseInt(SWA_CLI_DEVSERVER_TIMEOUT || "30000", 10),
   open: useEnvVarOrUseDefault(SWA_CLI_OPEN_BROWSER, false),
-  githubActionWorkflowLocation: SWA_RUNTIME_WORKFLOW_LOCATION ? path.resolve(SWA_RUNTIME_WORKFLOW_LOCATION) : undefined,
+  githubActionWorkflowLocation: SWA_RUNTIME_WORKFLOW_LOCATION ? SWA_RUNTIME_WORKFLOW_LOCATION : undefined,
 
   // swa login options
   useKeychain: useEnvVarOrUseDefault(SWA_CLI_LOGIN_USE_KEYCHAIN, true),

--- a/src/core/account.ts
+++ b/src/core/account.ts
@@ -262,7 +262,6 @@ export async function chooseOrCreateProjectDetails(options: SWACLIConfig, creden
     logger.error("No project found. Create a new project and try again.", true);
   }
 
-  process.exit(1);
   return;
 }
 

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -22,19 +22,13 @@ export function swaCLIEnv(...newEnvs: SWACLIEnv[]): SWACLIEnv {
   return env;
 }
 
-export function printEnv() {
+export function getSwaEnvList() {
   const env: SWACLIEnv = swaCLIEnv();
+  const entries = Object.entries(env)
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .filter(([key, _value]) => key.startsWith("SWA_") || key.startsWith("AZURE_"));
 
-  console.log("");
-  console.log("SWA CLI Environment variables:");
-  console.log("");
-
-  const entries = Object.entries(env).sort((a, b) => a[0].localeCompare(b[0]));
-  for (const [key, value] of entries) {
-    if (key.startsWith("SWA_") || key.startsWith("AZURE_")) {
-      console.log(`  ${key}: ${value}`);
-    }
-  }
+  return entries;
 }
 
 export function useEnvVarOrUseDefault(env: string | undefined, defaultValue: boolean): boolean {

--- a/src/core/prompts.ts
+++ b/src/core/prompts.ts
@@ -36,6 +36,24 @@ export async function wouldYouLikeToCreateStaticSite(): Promise<boolean> {
   return response.value;
 }
 
+export async function wouldYouLikeToOverrideStaticSite(appNameToOverride: string): Promise<boolean> {
+  const response = await promptOrUseDefault(false, {
+    type: "text",
+    name: "value",
+    message: `Project already exist! Enter project name to override:`,
+    warn: `Previous deployment in project "${appNameToOverride}" will be overwritten.`,
+    initial: "Press CTRL+L to cancel and exit",
+    validate: (value: string) => {
+      if (value === appNameToOverride) {
+        return true;
+      }
+      return `Confirmation doesn't match project name!`;
+    },
+  });
+
+  return response.value;
+}
+
 export async function chooseProjectName(initial: string, maxLength: number): Promise<string> {
   const response = await promptOrUseDefault(false, {
     type: "text",
@@ -113,7 +131,8 @@ export async function chooseStaticSite(staticSites: StaticSiteARMResource[], ini
     message: "Choose your Static Web App",
     initial: (_a: any, _b: Answers<"staticSite">, _c: PromptObject<string>) => {
       // Note: in case of a select prompt, initial is always an index
-      return choices.findIndex((choice) => choice.value === initial);
+      const index = choices.findIndex((choice) => choice.value === initial);
+      return index === -1 ? 0 : index;
     },
     choices,
   });

--- a/src/core/utils/cli-config.ts
+++ b/src/core/utils/cli-config.ts
@@ -1,23 +1,32 @@
+import chalk from "chalk";
+import { existsSync, promises as fsPromises } from "fs";
 import * as path from "path";
 import * as process from "process";
-import { existsSync, promises as fsPromises } from "fs";
-import { logger } from "./logger";
 import { DEFAULT_CONFIG } from "../../config";
+import { logger } from "./logger";
+const { readFile, writeFile } = fsPromises;
 
 export const swaCliConfigSchemaUrl = "https://aka.ms/azure/static-web-apps-cli/schema";
 export const swaCliConfigFilename = "swa-cli.config.json";
-const { readFile, writeFile } = fsPromises;
 
-export let currentConfig: SWACLIConfigInfo | undefined;
+/**
+ * Holds the current configuration of the CLI loaded from the `swa-cli.config.json` file.
+ */
+let currentSwaCliConfigFromFile: SWACLIConfigInfo | undefined;
 
-export const configExists = (configFilePath: string) => existsSync(configFilePath);
+export const getCurrentSwaCliConfigFromFile = () => currentSwaCliConfigFromFile;
+
+export const swaCliConfigFileExists = (configFilePath: string) => existsSync(configFilePath);
 
 export async function getConfigFileOptions(
   contextOrConfigEntry: string | undefined,
   configFilePath: string
 ): Promise<SWACLIConfig & { context?: string }> {
+  logger.silly(`Getting config file options from ${configFilePath}...`);
+
   configFilePath = path.resolve(configFilePath);
-  if (!configExists(configFilePath)) {
+  if (!swaCliConfigFileExists(configFilePath)) {
+    logger.silly(`Config file does not exist at ${configFilePath}`);
     return {};
   }
 
@@ -31,6 +40,8 @@ export async function getConfigFileOptions(
   const configDir = path.dirname(configFilePath);
   process.chdir(configDir);
 
+  logger.silly(`Changed directory to ${configDir}`);
+
   if (contextOrConfigEntry === DEFAULT_CONFIG.outputLocation) {
     const hasMultipleConfig = Object.entries(cliConfig.configurations).length > 1;
     if (hasMultipleConfig) {
@@ -41,20 +52,25 @@ export async function getConfigFileOptions(
 
     const [configName, config] = Object.entries(cliConfig.configurations)[0];
     printConfigMsg(configName, configFilePath);
-    currentConfig = {
+    currentSwaCliConfigFromFile = {
       name: configName,
       filePath: configFilePath,
-      config
-    }
+      config,
+    };
     return { ...config };
+  } else {
+    logger.silly(`Configuration="${contextOrConfigEntry}" does't match outputLocation="${DEFAULT_CONFIG.outputLocation}"`);
   }
 
   if (contextOrConfigEntry === undefined) {
+    logger.warn(`No configuration specified. Ignoring "${swaCliConfigFilename}"`);
     return {};
   }
 
   const config = cliConfig.configurations?.[contextOrConfigEntry];
   if (config) {
+    logger.silly(`Found configuration "${contextOrConfigEntry}" in "${swaCliConfigFilename}"`);
+
     printConfigMsg(contextOrConfigEntry, configFilePath);
     return { ...config };
   }
@@ -76,7 +92,7 @@ async function tryParseSwaCliConfig(file: string) {
 
 function printConfigMsg(name: string, file: string) {
   logger.log(`Using configuration "${name}" from file:`);
-  logger.log(`  ${file}`);
+  logger.log(chalk.green(`  ${file}`));
   logger.log("");
 }
 
@@ -85,11 +101,14 @@ export async function hasConfigurationNameInConfigFile(configFilePath: string, n
   return configJson.configurations?.[name] !== undefined;
 }
 
-export async function updateCurrentConfigFile(config: SWACLIConfig) {
-  if (currentConfig === undefined) {
-    throw new Error("No configuration file currently loaded");
+export async function updateSwaCliConfigFile(config: SWACLIConfig) {
+  if (currentSwaCliConfigFromFile === undefined) {
+    logger.error("No configuration file currently loaded", true);
+  } else {
+    logger.silly(`Updating configuration file at ${currentSwaCliConfigFromFile.filePath}`);
+
+    await writeConfigFile(currentSwaCliConfigFromFile.filePath, currentSwaCliConfigFromFile.name, config);
   }
-  await writeConfigFile(currentConfig.filePath, currentConfig.name, config);
 }
 
 export async function writeConfigFile(configFilePath: string, configName: string, config: SWACLIConfig) {
@@ -99,7 +118,9 @@ export async function writeConfigFile(configFilePath: string, configName: string
     configurations: {},
   };
 
-  if (configExists(configFilePath)) {
+  if (swaCliConfigFileExists(configFilePath)) {
+    logger.silly(`Loading existing swa-cli.config.json file at ${configFilePath}`);
+
     try {
       const configJson = await readFile(configFilePath, "utf-8");
       configFile = JSON.parse(configJson) as SWACLIConfigFile;
@@ -109,17 +130,21 @@ export async function writeConfigFile(configFilePath: string, configName: string
         logger.error(error);
       }
       logger.error("Cannot update existing configuration file.");
-      logger.error("Please fix or remove your swa-cli.config.json file and try again.");
+      logger.error("Please fix or delete your swa-cli.config.json file and try again.");
       return;
     }
   }
 
   if (configFile.configurations === undefined) {
+    logger.silly(`Creating "configurations" property in swa-cli.config.json file at ${configFilePath}`);
     configFile.configurations = {};
   }
 
   configFile.configurations[configName] = config;
   try {
+    logger.silly(`Writing configuration "${configName}" to swa-cli.config.json`);
+    logger.silly(config);
+
     await writeFile(configFilePath, JSON.stringify(configFile, null, 2));
   } catch (error) {
     logger.error(`Error writing configuration to ${configFilePath}`);

--- a/src/core/utils/logger.ts
+++ b/src/core/utils/logger.ts
@@ -68,7 +68,7 @@ export const logger = {
 
     console.error(chalk.red("✖ " + data));
     if (exit) {
-      process.exit(-1);
+      process.exit(1);
     }
   },
 

--- a/src/core/utils/net.ts
+++ b/src/core/utils/net.ts
@@ -94,7 +94,7 @@ export async function validateDevServerConfig(context: string | undefined, timeo
       } catch (err) {
         spinner.fail();
         logger.error(`Could not connect to "${context}". Is the server up and running?`);
-        process.exit(-1);
+        process.exit(1);
       }
     }
   } catch (err) {
@@ -105,7 +105,7 @@ export async function validateDevServerConfig(context: string | undefined, timeo
     } else {
       logger.error((err as any).message);
     }
-    process.exit(-1);
+    process.exit(1);
   }
 }
 

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -32,6 +32,7 @@ declare interface SWACLIEnv {
   SWA_CLI_DEPLOYMENT_TOKEN?: string;
   SWA_RUNTIME_CONFIG?: string;
   SWA_CLI_VERSION?: string;
+  AZURE_REGION_LOCATION?: string;
 
   // swa build
   SWA_CLI_APP_BUILD_COMMAND?: string;
@@ -201,7 +202,7 @@ declare type SWACLIConfig = SWACLIOptionsToCleanUp &
     init?: SWACLIGlobalOptions & SWACLIInitOptions & SWACLIContextOptions;
     start?: SWACLIGlobalOptions & SWACLIStartOptions & SWACLIContextOptions;
     deploy?: SWACLIGlobalOptions & SWACLIDeployOptions & SWACLIContextOptions;
-};
+  };
 
 // Information about the loaded config
 declare type SWACLIConfigInfo ={

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -162,6 +162,7 @@ declare type SWACLIDeployOptions = SWACLISharedLoginOptions & {
   outputLocation?: string;
   deploymentToken?: string;
   dryRun?: boolean;
+  printToken?: boolean;
 };
 
 // -- CLI Login options ------------------------------------------------------
@@ -205,11 +206,11 @@ declare type SWACLIConfig = SWACLIOptionsToCleanUp &
   };
 
 // Information about the loaded config
-declare type SWACLIConfigInfo ={
+declare type SWACLIConfigInfo = {
   filePath: string;
   name: string;
-  config: SWACLIConfig
-}
+  config: SWACLIConfig;
+};
 
 declare type ResponseOptions = {
   [key: string]: any;


### PR DESCRIPTION
Supported scenarios when deploying:

- [x] the user should be authenticated
    - [x] if a user is logged out, they should be able to login in during deployment if they are not
    - [x] if the user is already logged in, they should process to deployment without being prompted
    - [x] if Azure tenant is not selected, the user should be able to select one during the deployment
    - [x] if only one Azure tenant is available, it will be automatically selected without prompting the user
    - [x] if no Azure tenant is found, the deployment process is stopped.
    - [x] if an Azure subscription is not selected, the user should be able to select one during the deployment
    - [x] if only one Azure subscription is available, it will be automatically selected without prompting the user
    - [x] if no Azure subscription is found, the deployment process is stopped.
- [x] the user should select a valid project
    - [x] if no project details were found, the user should be able to select a project
    - [x] if multiple projects are found, list all projects in the format `resource-group/swa`
    - [x] if no project was found, prompt the user to create a new project
    - [x] if the user provides `appName`, use it as a default name
    - [x] if the user provides does not provide an `appName`, use the current folder name as a default `appName`
    - [x] if the user has a set `configurations.ID.deploy.appName` in the `swa-cli.config.json` file, use it as a default `appName`
    - [x] if multiple projects are found:
        - [x] if the project is available, show a list of projects and highlight that project
        - [x] if the project is NOT available, show a list of projects and highlight the CREATE option
    - [x] if one project is found:
        - [x] the project is available, automatically select that project without prompting the user
        - [x] the project is NOT available, prompt the user to create a new project using the provided name 
    - [x] when creating a project, if the project already exists, prompt the user to override the existing project
    - [x] on success, the user should be able to see the URL of the deployed project
        - [ ] users should access their custom domain (if it's set) 

- [ ] the `--yes` mode
    - [ ] if the user provides `appName`, use it as a default name
    - [ ] if the user provides does not provide an `appName`, use the current folder name as an `appName`
    - [ ] do not prompt the user for any questions (assume `yes` to all prompts) and use these defaults:
        - [ ] if no project is found, automatically create a new one using `appName`
        - [ ] if one project is found
            - [ ] if it matched `appName`, use it
            - [ ] if it doesn't match `appName`, create a new project using `appName`
        - [ ] if multiple projects were found
            - [ ] if `appName` is in the list, use it
            - [ ]  if `appName` is NOT in the list, create a new project using `appName` 

- [x] the `--dry-run` mode
    - [x] skip the whole deployment process
    - [x] ignore missing deployment token error message (that's expected untill StaticSitesClient implements a dry-run mode)

- [x] error handling
    - [x] the deployment should exit on any error
    - [x] if the user press CTRL+C during any step, the deployment should exit.
    - [x] if the selected project is already linked to a different provider, error, and exit.
    - [x] if the users reaches the quota in the default Azure region, they should be able to override the default location using `AZURE_REGION_LOCATION="azure-region"`

- [ ] other
    - [ ] deployment token should NOT be stored in `swa-cli.config.json` file