### PR TITLE
docs: modified links in the readme file.

### DIFF
--- a/docs/www/docs/cli/swa-build.md
+++ b/docs/www/docs/cli/swa-build.md
@@ -62,6 +62,6 @@ swa build myApp
 
 ## See Also
 
-- [swa](docs/cli/swa) - The Static Web Apps CLI
-- [swa start](swa-start)
-- [swa deploy](swa-deploy)
+- [swa](https://azure.github.io/static-web-apps-cli/docs/cli/swa) - The Static Web Apps CLI
+- [swa start](https://azure.github.io/static-web-apps-cli/docs/cli/swa-start)
+- [swa deploy](https://azure.github.io/static-web-apps-cli/docs/cli/swa-deploy)

--- a/docs/www/docs/cli/swa-config.md
+++ b/docs/www/docs/cli/swa-config.md
@@ -105,9 +105,9 @@ The `swa-cli.config.json` file can be validated against the following schema: ht
 
 ## See Also
 
-- [swa](docs/cli/swa) - The Static Web Apps CLI
-- [swa-init](docs/cli/swa-init)
-- [swa-start](docs/cli/swa-start)
+- [swa](https://azure.github.io/static-web-apps-cli/docs/cli/swa) - The Static Web Apps CLI
+- [swa-init](https://azure.github.io/static-web-apps-cli/docs/cli/swa-init)
+- [swa-start](https://azure.github.io/static-web-apps-cli/docs/cli/swa-start)
 
 <!--
 ## Configuration File

--- a/docs/www/docs/cli/swa-deploy.md
+++ b/docs/www/docs/cli/swa-deploy.md
@@ -45,7 +45,7 @@ Don't store the deployment token in a public repository. It should be kept secre
 
 You can deploy a front-end application (without an API) to Azure Static Web Apps by running the following steps:
 
-1. If your front-end application requires a build step, run [`swa build`](swa-build) or refer to your application build instructions.
+1. If your front-end application requires a build step, run [`swa build`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-build) or refer to your application build instructions.
 
 **Option 1:** From build folder you would like to deploy, run the deploy command:
 
@@ -58,7 +58,7 @@ swa deploy
 
 **Option 2:** You can also deploy a specific folder:
 
-1. If your front-end application requires a build step, run [`swa build`](swa-build) or refer to your application build instructions.
+1. If your front-end application requires a build step, run [`swa build`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-build) or refer to your application build instructions.
 
 2. Deploy your app:
 
@@ -70,7 +70,7 @@ swa deploy ./my-dist
 
 To deploy both the front-end app and an API to Azure Static Web Apps, use the following steps:
 
-1. If your front-end application requires a build step, run [`swa build`](swa-build) or refer to your application build instructions.
+1. If your front-end application requires a build step, run [`swa build`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-build) or refer to your application build instructions.
 
 2. Make sure the[ API language runtime version](https://docs.microsoft.com/en-us/azure/static-web-apps/configuration#platform) in the `staticwebapp.config.json` file is set correctly, for example:
 
@@ -132,7 +132,7 @@ If you are using a [`swa-cli.config.json`](#swa-cli.config.json) configuration f
 
 Then you can deploy your application by running the following steps:
 
-1. If your front-end application requires a build step, run [`swa build`](swa-build) or refer to your application build instructions.
+1. If your front-end application requires a build step, run [`swa build`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-build) or refer to your application build instructions.
 
 2. Deploy your app:
 
@@ -204,6 +204,6 @@ swa deploy --env production
 
 ## See Also
 
-- [swa](docs/cli/swa)
-- [swa login](swa-login)
-- [Environment Variables](env-vars)
+- [swa](https://azure.github.io/static-web-apps-cli/docs/cli/swa)
+- [swa login](https://azure.github.io/static-web-apps-cli/docs/cli/swa-login)
+- [Environment Variables](https://azure.github.io/static-web-apps-cli/docs/cli/env-vars)

--- a/docs/www/docs/cli/swa-login.md
+++ b/docs/www/docs/cli/swa-login.md
@@ -13,7 +13,7 @@ swa login [options]
 
 Used to login to Azure.
 
-This command is used to authenticate with Azure and get a deployment token that can be used to deploy to Azure Static Web Apps, using the [`swa deploy`](swa-deploy) command.
+This command is used to authenticate with Azure and get a deployment token that can be used to deploy to Azure Static Web Apps, using the [`swa deploy`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-deploy) command.
 
 ## Options
 
@@ -68,5 +68,5 @@ swa login --tenant-id 00000000-0000-0000-0000-000000000000 \
 
 ## See Also
 
-- [swa deploy](docs/cli/swa-deploy)
-- [swa](docs/cli/swa)
+- [swa deploy](https://azure.github.io/static-web-apps-cli/docs/cli/swa-deploy)
+- [swa](https://azure.github.io/static-web-apps-cli/docs/cli/swa)

--- a/docs/www/docs/cli/swa-start.md
+++ b/docs/www/docs/cli/swa-start.md
@@ -162,4 +162,4 @@ swa start http://localhost:3000 --api-location http://localhost:7071
 
 ## See Also
 
-- [swa](docs/cli/swa) - The Static Web Apps CLI
+- [swa](https://azure.github.io/static-web-apps-cli/docs/cli/swa) - The Static Web Apps CLI

--- a/docs/www/docs/cli/swa.md
+++ b/docs/www/docs/cli/swa.md
@@ -38,11 +38,11 @@ Here are global options that you can use with any command supported by the `swa`
 
 Here are the currently supported `swa` commands. Use `swa <command> --help` to learn about options and usage for that particular command.
 
-- [`login`](swa-login): login into Azure
-- [`init`](swa-init): initialize a new static web app project
-- [`start`](swa-start): start the emulator from a directory or bind to a dev server
-- [`deploy`](swa-deploy): deploy the current project to Azure Static Web Apps
-- [`build`](swa-build): build your project
+- [`login`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-login): login into Azure
+- [`init`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-init): initialize a new static web app project
+- [`start`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-start): start the emulator from a directory or bind to a dev server
+- [`deploy`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-deploy): deploy the current project to Azure Static Web Apps
+- [`build`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-build): build your project
 
 ## Usage
 
@@ -54,10 +54,10 @@ swa
 
 ## See Also
 
-- [swa init](docs/cli/swa-init)
-- [swa build](docs/cli/swa-build)
-- [swa start](docs/cli/swa-start)
-- [swa login](docs/cli/swa-login)
-- [swa deploy](docs/cli/swa-deploy)
-- [Configuring CLI](docs/cli/swa-config) - file location, defaults
-- [Environment Vars](docs/cli/swa-deploy) - supported settings
+- [swa init](https://azure.github.io/static-web-apps-cli/docs/cli/swa-init)
+- [swa build](https://azure.github.io/static-web-apps-cli/docs/cli/swa-build)
+- [swa start](https://azure.github.io/static-web-apps-cli/docs/cli/swa-start)
+- [swa login](https://azure.github.io/static-web-apps-cli/docs/cli/swa-login)
+- [swa deploy](https://azure.github.io/static-web-apps-cli/docs/cli/swa-deploy)
+- [Configuring CLI](https://azure.github.io/static-web-apps-cli/docs/cli/swa-config) - file location, defaults
+- [Environment Vars](https://azure.github.io/static-web-apps-cli/docs/cli/swa-deploy) - supported settings

--- a/docs/www/docs/intro.md
+++ b/docs/www/docs/intro.md
@@ -7,8 +7,8 @@ sidebar_position: 1
 The **Static Web Apps (SWA) CLI** is an open-source commandline tool that streamlines local development and deployment for Azure Static Web Apps.
 
 - Find it on npm: [@azure/static-web-apps-cli](https://www.npmjs.com/package/@azure/static-web-apps-cli)
-- Get Started: [Install the SWA CLI](docs/use/install)
-- Contribute: [Build from Source](docs/contribute/developer)
+- Get Started: [Install the SWA CLI](https://azure.github.io/static-web-apps-cli/docs/use/install)
+- Contribute: [Build from Source](https://azure.github.io/static-web-apps-cli/docs/contribute/developer)
 
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/azure/static-web-apps-cli/issues)
 

--- a/docs/www/docs/use/1-install.md
+++ b/docs/www/docs/use/1-install.md
@@ -44,17 +44,17 @@ swa
 
 It will generate a configuration for you, then build your project and ask if you want to deploy it to Azure.
 
-See [swa](../cli/swa) for more details.
+See [swa](https://azure.github.io/static-web-apps-cli/docs/cli/swa) for more details.
 
 ## Extended usage
 
 Here are the currently supported `swa` commands. Use `swa <command> --help` to learn about options and usage for that particular command.
 
-- [`login`](../cli/swa-login): login into Azure
-- [`init`](../cli/swa-init): initialize a new static web app project
-- [`start`](../cli/swa-start): start the emulator from a directory or bind to a dev server
-- [`deploy`](../cli/swa-deploy): deploy the current project to Azure Static Web Apps
-- [`build`](../cli/swa-build): build your project
+- [`login`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-login): login into Azure
+- [`init`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-init): initialize a new static web app project
+- [`start`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-start): start the emulator from a directory or bind to a dev server
+- [`deploy`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-deploy): deploy the current project to Azure Static Web Apps
+- [`build`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-build): build your project
 
 ## Run using npx
 

--- a/docs/www/docs/use/2-emulator.md
+++ b/docs/www/docs/use/2-emulator.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 The SWA Emulator is run by using the `swa start` command.
 
 - It runs on `http://localhost:4280` by default.
-- Read the [docs](/docs/cli/swa-start) for more command details.
+- Read the [docs](https://azure.github.io/static-web-apps-cli/docs/cli/swa-start) for more command details.
 
 ## 2.1 Serve from current folder
 

--- a/readme.md
+++ b/readme.md
@@ -52,11 +52,11 @@ See [swa](https://azure.github.io/static-web-apps-cli/) for more details.
 
 Here are the currently supported `swa` commands. Use `swa <command> --help` to learn about options and usage for that particular command.
 
-- [`login`](https://azure.github.io/static-web-apps-cli//cli/swa-login): login into Azure
-- [`init`](https://azure.github.io/static-web-apps-cli//cli/swa-init): initialize a new static web app project
-- [`start`](https://azure.github.io/static-web-apps-cli//cli/swa-start): start the emulator from a directory or bind to a dev server
-- [`deploy`](https://azure.github.io/static-web-apps-cli//cli/swa-deploy): deploy the current project to Azure Static Web Apps
-- [`build`](https://azure.github.io/static-web-apps-cli//cli/swa-build): build your project
+- [`login`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-login): login into Azure
+- [`init`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-init): initialize a new static web app project
+- [`start`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-start): start the emulator from a directory or bind to a dev server
+- [`deploy`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-deploy): deploy the current project to Azure Static Web Apps
+- [`build`](https://azure.github.io/static-web-apps-cli/docs/cli/swa-build): build your project
 
 ### Using `npx`:
 


### PR DESCRIPTION
Links redirecting to "login", "init", "start", "deploy" from Readme are not working