### PR TITLE
Use appDevserverUrl for URL configuration

### DIFF
--- a/docs/www/docs/cli/swa-config.md
+++ b/docs/www/docs/cli/swa-config.md
@@ -25,7 +25,7 @@ The configuration file can contain multiple configurations (e.g., one per projec
 {
   "configurations": {
     "app": {
-      "outputLocation": "http://localhost:3000",
+      "appDevserverUrl": "http://localhost:3000",
       "apiLocation": "api",
       "run": "npm run start",
       "swaConfigLocation": "./my-app-source"


### PR DESCRIPTION
This used to be `context` section (prior to v1.0.0).
![image](https://user-images.githubusercontent.com/17608272/169205825-6057d990-24bf-4cae-993e-75fa22299c5d.png)

https://raw.githubusercontent.com/Azure/static-web-apps-cli/main/schema/swa-cli.config.schema.json
```json
"appLocation": {
  "description": "The folder containing the source code of the front-end application",
  "type": "string"
},
"outputLocation": {
  "description": "The folder containing the built source of the front-end application",
  "type": "string"
},
"apiLocation": {
  "description": "The folder containing the source code of the API application",
  "type": "string"
},
"appDevserverUrl": {
  "description": "Connect to the dev server at this URL instead of using output location",
  "type": "string"
},
"apiDevserverUrl": {
  "description": "Connect to the api server at this URL instead of using api location",
  "type": "string"
},
```
