### PR TITLE
docs: fix typo in swa-init page

### DIFF
--- a/docs/www/docs/cli/swa-init.md
+++ b/docs/www/docs/cli/swa-init.md
@@ -15,7 +15,7 @@ This command is used to configure your project to use with the Static Web Apps C
 It will ask for a configuration name, detect your project settings and the frameworks used and create a `swa-cli.config.json` file in the current directory.
 You can use this file to configure any options for the CLI.
 
-Note that you can run `swa init` multiples times to create different configurations for your project. This is useful for example if you're working on a monorepo and want to configure different projects.
+Note that you can run `swa init` multiple times to create different configurations for your project. This is useful for example if you're working on a monorepo and want to configure different projects.
 
 The generated configuration file will be used in every command you run with the Static Web Apps CLI.
 If you have multiple named configurations, you can use the positional argument or `--config-name` option to specify which one you want to use, see usage examples below.


### PR DESCRIPTION
fix typo multiples -> multiple