### PR TITLE
fix(core): identify correct default port for http and https urls

### DIFF
--- a/src/core/utils/net.spec.ts
+++ b/src/core/utils/net.spec.ts
@@ -1,6 +1,6 @@
 jest.mock("../constants", () => {});
 import { logger } from "./logger";
-import { address, hostnameToIpAdress, parsePort, response } from "./net";
+import { address, hostnameToIpAdress, parsePort, parseUrl, response } from "./net";
 
 describe("net utilities", () => {
   describe("response()", () => {
@@ -296,6 +296,18 @@ describe("net utilities", () => {
 
     it("should ignore host names", () => {
       expect(hostnameToIpAdress("foo.bar")).toBe("foo.bar");
+    });
+  });
+
+  describe("parseUrl()", () => {
+    it("should specify port 443 for https URLs", () => {
+      expect(parseUrl("https://foo.com")).toMatchObject({ port: 443 });
+    });
+    it("should specify port 80 for http URLs", () => {
+      expect(parseUrl("http://foo.com")).toMatchObject({ port: 80 });
+    });
+    it("should parse the port given in the URL", () => {
+      expect(parseUrl("https://foo.com:9999")).toMatchObject({ port: 9999 });
     });
   });
 });

--- a/src/core/utils/net.ts
+++ b/src/core/utils/net.ts
@@ -127,7 +127,18 @@ export function parseUrl(url: string | undefined) {
     throw new Error(`Address: ${url} is malformed!`);
   }
 
-  const { protocol, port, host, hostname } = new URL(url);
+  let { protocol, port, host, hostname } = new URL(url);
+  if (port === "") {
+    switch (protocol) {
+      case "http:":
+        port = "80";
+        break;
+      case "https:":
+        port = "443";
+        break;
+    }
+  }
+
   return {
     protocol,
     port: Number(port),


### PR DESCRIPTION
Ensure the correct default port is parsed from http and https URLs.

Before this change, URLs used to identify remote API servers might be parsed as using port 0. swa-cli would then attempt to make a TCP connection to port 0 and would eventually timeout.

With this change, ports for remote API servers are now correctly identified and connections are made to the server without the timeout occuring.

Relates to #523