### PR TITLE
feat(start): allow insecure https connections to remote api hosts

### DIFF
--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -35,8 +35,21 @@ export default function registerCommand(program: Command) {
     .option("-a, --app-location <path>", "the folder containing the source code of the front-end application", DEFAULT_CONFIG.appLocation)
     .option("-i, --api-location <path>", "the folder containing the source code of the API application", DEFAULT_CONFIG.apiLocation)
     .option("-O, --output-location <path>", "the folder containing the built source of the front-end application", DEFAULT_CONFIG.outputLocation)
-    .option("-D, --app-devserver-url <url>", "connect to the app dev server at this URL instead of using output location", DEFAULT_CONFIG.appDevserverUrl)
-    .option("-is, --api-devserver-url <url>", "connect to the api server at this URL instead of using output location", DEFAULT_CONFIG.apiDevserverUrl)
+    .option(
+      "-D, --app-devserver-url <url>",
+      "connect to the app dev server at this URL instead of using output location",
+      DEFAULT_CONFIG.appDevserverUrl
+    )
+    .option(
+      "-is, --api-devserver-url <url>",
+      "connect to the api server at this URL instead of using output location",
+      DEFAULT_CONFIG.apiDevserverUrl
+    )
+    .option(
+      "-ik, --api-devserver-insecure",
+      "allow insecure connections to the API server. Useful when HTTPS API server uses wildcard certificates.",
+      DEFAULT_CONFIG.apiDevserverInsecure
+    )
     .option<number>("-j, --api-port <apiPort>", "the API server port passed to `func start`", parsePort, DEFAULT_CONFIG.apiPort)
     .option("-q, --host <host>", "the host address to use for the CLI dev server", DEFAULT_CONFIG.host)
     .option<number>("-p, --port <port>", "the port value to use for the CLI dev server", parsePort, DEFAULT_CONFIG.port)
@@ -108,6 +121,9 @@ swa start http://localhost:3000 --run-build "npm start"
 
 Connect both front-end and the API to running development server
 swa start http://localhost:3000 --api-location http://localhost:7071
+
+Connect the front-end to a local development server and proxy API request to a remote functions host
+swa start http://localhost:3000 --api-location remote --api-devserver-url https://codespacesname-1234567890123-7071.githubpreview.dev --api-devserver-insecure
   `
     );
 }
@@ -124,6 +140,7 @@ export async function start(options: SWACLIConfig) {
     outputLocation,
     appDevserverUrl,
     apiDevserverUrl,
+    apiDevserverInsecure,
     apiPort,
     devserverTimeout,
     ssl,
@@ -309,6 +326,7 @@ export async function start(options: SWACLIConfig) {
     SWA_CLI_APP_LOCATION: userWorkflowConfig?.appLocation as string,
     SWA_CLI_OUTPUT_LOCATION: userWorkflowConfig?.outputLocation as string,
     SWA_CLI_API_LOCATION: userWorkflowConfig?.apiLocation as string,
+    SWA_CLI_API_DEVSERVER_INSECURE: apiDevserverInsecure ? "true" : "false",
     SWA_CLI_HOST: `${host}`,
     SWA_CLI_PORT: `${port}`,
     SWA_CLI_APP_SSL: ssl ? "true" : "false",

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,7 @@ const {
   SWA_CLI_LOGIN_CLEAR_CREDENTIALS,
   SWA_CLI_APP_DEVSERVER_URL,
   SWA_CLI_API_DEVSERVER_URL,
+  SWA_CLI_API_DEVSERVER_INSECURE,
 } = swaCLIEnv();
 
 export const DEFAULT_CONFIG: SWACLIConfig = {
@@ -57,6 +58,7 @@ export const DEFAULT_CONFIG: SWACLIConfig = {
   dryRun: useEnvVarOrUseDefault(SWA_CLI_DEPLOY_DRY_RUN, false),
   appDevserverUrl: SWA_CLI_APP_DEVSERVER_URL || undefined,
   apiDevserverUrl: SWA_CLI_API_DEVSERVER_URL || undefined,
+  apiDevserverInsecure: SWA_CLI_API_DEVSERVER_INSECURE === "true",
 
   // swa login options
   subscriptionId: AZURE_SUBSCRIPTION_ID || undefined,

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -194,3 +194,7 @@ export function IS_API_DEV_SERVER() {
 export function SWA_CLI_API_URI() {
   return IS_API_DEV_SERVER() ? DEFAULT_CONFIG.apiLocation : address(DEFAULT_CONFIG.host, DEFAULT_CONFIG.apiPort);
 }
+
+export function SWA_CLI_API_ALLOW_INSECURE(): boolean {
+  return IS_API_DEV_SERVER() && (DEFAULT_CONFIG.apiDevserverInsecure ?? false);
+}

--- a/src/msha/handlers/function.handler.ts
+++ b/src/msha/handlers/function.handler.ts
@@ -3,7 +3,7 @@ import type http from "http";
 import httpProxy from "http-proxy";
 import fetch from "node-fetch";
 import { decodeCookie, logger, logRequest, registerProcessExit, validateCookie } from "../../core";
-import { HAS_API, SWA_CLI_API_URI } from "../../core/constants";
+import { HAS_API, SWA_CLI_API_ALLOW_INSECURE, SWA_CLI_API_URI } from "../../core/constants";
 import { onConnectionLost } from "../middlewares/request.middleware";
 
 const proxyApi = httpProxy.createProxyServer({ autoRewrite: true });
@@ -55,6 +55,8 @@ function injectClientPrincipalCookies(req: http.ClientRequest) {
 
 export function handleFunctionRequest(req: http.IncomingMessage, res: http.ServerResponse) {
   const target = SWA_CLI_API_URI();
+  const allowInsecure = SWA_CLI_API_ALLOW_INSECURE();
+
   if (HAS_API) {
     logger.silly(`function request detected. Proxying to Azure Functions emulator`);
     logger.silly(` - target: ${chalk.yellow(target)}`);
@@ -70,6 +72,9 @@ export function handleFunctionRequest(req: http.IncomingMessage, res: http.Serve
     res,
     {
       target,
+      secure: !allowInsecure,
+      // Set the host header to match the function host.
+      changeOrigin: true,
     },
     onConnectionLost(req, res, target, "↳")
   );

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -45,6 +45,7 @@ declare interface SWACLIEnv extends StaticSiteClientEnv {
   SWA_CLI_OPEN_BROWSER?: string;
   SWA_CLI_APP_DEVSERVER_URL?: string;
   SWA_CLI_API_DEVSERVER_URL?: string;
+  SWA_CLI_API_DEVSERVER_INSECURE?: string;
 
   // swa deploy
   SWA_CLI_DEPLOY_DRY_RUN?: string;
@@ -128,6 +129,7 @@ declare type SWACLIStartOptions = {
   apiLocation?: string;
   appDevserverUrl?: string;
   apiDevserverUrl?: string;
+  apiDevserverInsecure?: boolean;
   apiPort?: number;
   host?: string;
   port?: number;


### PR DESCRIPTION
Allow insecure connections to remote api hosts to handle cases where remote TLS host presents a wildcard certificate.

Change the host header in proxied requests from localhost to match the remote api host.

Relates to #523