### PR TITLE
Update 99-troubleshooting.md

### DIFF
--- a/docs/www/docs/contribute/99-troubleshooting.md
+++ b/docs/www/docs/contribute/99-troubleshooting.md
@@ -37,8 +37,8 @@ In order to be able to automatically deploy your app to your Azure Static Web Ap
 In order to avoid this issue, you have a few options:
 1. [Manually install](https://www.google.com/search?q=instal+libsecret) `libsecret` by adding it to your Docker image or your system (recommended)
 2. Disable Keychain access using `--no-use-keychain`. Doing so won't store and remember your credentials anymore, and you will have to interactively log in again each time you run `swa login`
-3. Manually provide the Deployment Token for your current project (see [SWA CLI docs](https://azure.github.io/static-web-apps-cli/docs/use/deploy#51-deployment-token)). You will also need to provide `--app-name` and `--resource-group-name`
-4. Manually provide `--client-id`, `--client-secret`, `--app-name` and `--resource-group-name`.
+3. Manually provide the Deployment Token for your current project (see [SWA CLI docs](https://azure.github.io/static-web-apps-cli/docs/use/deploy#51-deployment-token)). You will also need to provide `--app-name` and `--resource-group`
+4. Manually provide `--client-id`, `--client-secret`, `--app-name` and `--resource-group`.
 
 
 ---


### PR DESCRIPTION
The correct flag for specifying the resource group is `--resource-group` not `--resource-group-name` as was previously stated