### PR TITLE
fix(command:init): dev command for Next.Js projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15666,8 +15666,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.16.2",
@@ -16376,8 +16375,7 @@
     "ajv-draft-04": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-      "requires": {}
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="
     },
     "all-contributors-cli": {
       "version": "6.20.0",
@@ -19693,8 +19691,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -24988,8 +24985,7 @@
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
       "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/src/core/frameworks/frameworks.ts
+++ b/src/core/frameworks/frameworks.ts
@@ -84,9 +84,9 @@ export const appFrameworks: FrameworkDefinition[] = [
     packages: ["next"],
     config: {
       appBuildCommand: "npm run build",
-      appDevserverCommand: "npm dev",
+      appDevserverCommand: "npm run dev",
       appDevserverUrl: "http://localhost:3000",
-      outputLocation: ".",
+      outputLocation: ".next",
     },
   },
   {


### PR DESCRIPTION
Pull Request related with #553 

## Results

I made some screenshots to show that it is working now. To reproduce, follow the steps below:

1 - Create any Next.Js project. Eg

```bash
npx create-next-app --example hello-world hello-world-app
```

2 - Now run the command 

```bash
swa init
```

After to execute the command it will generate a file **swa-cli.config** with the configuration

```json
{
  "$schema": "https://aka.ms/azure/static-web-apps-cli/schema",
  "configurations": {
    "hello-world-app-glau": {
      "appLocation": ".",
      "outputLocation": ".next",
      "appBuildCommand": "npm run build",
      "run": "npm run dev",
      "appDevserverUrl": "http://localhost:3000"
    }
  }
}
```

![Screen Shot 09-09-22 at 07 23 PM 002](https://user-images.githubusercontent.com/1631477/189455363-f88e0145-cbae-4d28-bbc4-5e77ef69ffde.PNG)

4 - Now execute the command

```bash
swa start
```

![Screen Shot 09-09-22 at 07 23 PM](https://user-images.githubusercontent.com/1631477/189455389-016bab9c-ad1a-43a6-985f-9f5cbf30c48e.PNG)

And open a browser on port **localhost:4280**. If you see the message: 'Hello World' it is because it's working perfectly.

![Screen Shot 09-09-22 at 07 23 PM 001](https://user-images.githubusercontent.com/1631477/189455346-6ed1d8d6-b4ce-4276-a6e3-e0dbcfe4cf01.PNG)
