### PR TITLE
fix(api): Node18 support

### DIFF
--- a/src/core/func-core-tools.spec.ts
+++ b/src/core/func-core-tools.spec.ts
@@ -66,9 +66,12 @@ describe("funcCoreTools", () => {
       expect(isCoreToolsVersionCompatible(4, 16)).toBe(true);
       expect(isCoreToolsVersionCompatible(3, 16)).toBe(false);
       expect(isCoreToolsVersionCompatible(2, 16)).toBe(false);
-      expect(isCoreToolsVersionCompatible(4, 17)).toBe(false);
+      expect(isCoreToolsVersionCompatible(4, 17)).toBe(true);
       expect(isCoreToolsVersionCompatible(3, 17)).toBe(false);
       expect(isCoreToolsVersionCompatible(2, 17)).toBe(false);
+      expect(isCoreToolsVersionCompatible(4, 18)).toBe(true);
+      expect(isCoreToolsVersionCompatible(3, 18)).toBe(false);
+      expect(isCoreToolsVersionCompatible(2, 18)).toBe(false);
     });
   });
 

--- a/src/core/func-core-tools.ts
+++ b/src/core/func-core-tools.ts
@@ -42,7 +42,7 @@ export function isCoreToolsVersionCompatible(coreToolsVersion: number, nodeVersi
   // Runtime support reference: https://docs.microsoft.com/azure/azure-functions/functions-versions?pivots=programming-language-javascript#languages
   switch (coreToolsVersion) {
     case 4:
-      return nodeVersion >= 14 && nodeVersion <= 16;
+      return nodeVersion >= 14 && nodeVersion <= 18;
     case 3:
       return nodeVersion >= 10 && nodeVersion <= 14;
     case 2:
@@ -54,7 +54,7 @@ export function isCoreToolsVersionCompatible(coreToolsVersion: number, nodeVersi
 
 export function detectTargetCoreToolsVersion(nodeVersion: number): number {
   // Pick the highest version that is compatible with the specified Node version
-  if (nodeVersion >= 14 && nodeVersion <= 16) return 4;
+  if (nodeVersion >= 14 && nodeVersion <= 18) return 4;
   if (nodeVersion >= 10 && nodeVersion < 14) return 3;
   if (nodeVersion >= 8 && nodeVersion < 10) return 2;
 


### PR DESCRIPTION
With the recent release of support for Node 18 in the Functions v4 runtime, we should update the tools check code to allow that.