### PR TITLE
Updating deployment provider

### DIFF
--- a/src/cli/commands/deploy.spec.ts
+++ b/src/cli/commands/deploy.spec.ts
@@ -130,7 +130,7 @@ describe("deploy", () => {
     expect(child_process.spawn).toBeCalledWith("mock-binary", [], {
       env: {
         DEPLOYMENT_ACTION: "upload",
-        DEPLOYMENT_PROVIDER: `swa-cli-${pkg.version}`,
+        DEPLOYMENT_PROVIDER: "SwaCli",
         REPOSITORY_BASE: "./",
         SKIP_APP_BUILD: "true",
         SKIP_API_BUILD: "true",
@@ -166,7 +166,7 @@ describe("deploy", () => {
     expect(child_process.spawn).toBeCalledWith("mock-binary", [], {
       env: {
         DEPLOYMENT_ACTION: "upload",
-        DEPLOYMENT_PROVIDER: `swa-cli-${pkg.version}`,
+        DEPLOYMENT_PROVIDER: "SwaCli",
         REPOSITORY_BASE: "./",
         SKIP_APP_BUILD: "true",
         SKIP_API_BUILD: "true",

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -252,7 +252,7 @@ export async function deploy(options: SWACLIConfig) {
 
   const deployClientEnv: StaticSiteClientEnv = {
     DEPLOYMENT_ACTION: options.dryRun ? "close" : "upload",
-    DEPLOYMENT_PROVIDER: `swa-cli-${packageInfo.version}`,
+    DEPLOYMENT_PROVIDER: "SwaCli",
     REPOSITORY_BASE: userWorkflowConfig?.appLocation,
     SKIP_APP_BUILD: "true",
     SKIP_API_BUILD: "true",


### PR DESCRIPTION
Static Web Apps is unable to detect SwaCLI as a deployment provider with version included.