### PR TITLE
feat(start): set host header in proxied requests to match remote API hosts

### DIFF
--- a/src/msha/handlers/function.handler.ts
+++ b/src/msha/handlers/function.handler.ts
@@ -70,6 +70,8 @@ export function handleFunctionRequest(req: http.IncomingMessage, res: http.Serve
     res,
     {
       target,
+      // Set the host header to match the remote API host.
+      changeOrigin: true,
     },
     onConnectionLost(req, res, target, "↳")
   );


### PR DESCRIPTION
Changes the host header from localhost to the remote API host, permitting a host match to be found against the remote host's certificate.

Relates to #523
