### PR TITLE
fix: providing separate agents for HTTP and HTTPS proxy servers

### DIFF
--- a/docs/www/docs/cli/swa-start.md
+++ b/docs/www/docs/cli/swa-start.md
@@ -160,6 +160,10 @@ Connect both front-end and the API to running development server
 swa start http://localhost:3000 --api-devserver-url http://localhost:7071
 ```
 
+:::info Note
+To make a secure connection, hit a https dev server only if you start the CLI using the flag --ssl.
+:::
+
 ## See Also
 
 - [swa](./swa)

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -116,7 +116,6 @@ swa start http://localhost:3000 --api-devserver-url http://localhost:7071
     );
 }
 
-export var isSSL: boolean = false;
 export async function start(options: SWACLIConfig) {
   // WARNING:
   // environment variables are populated using values provided by the user to the CLI.
@@ -275,7 +274,6 @@ export async function start(options: SWACLIConfig) {
   }
 
   if (ssl) {
-    isSSL = ssl;
     if (sslCert === undefined && sslKey === undefined) {
       logger.warn(`WARNING: Using built-in UNSIGNED certificate. DO NOT USE IN PRODUCTION!`);
       const pemFilepath = await getCertificate({

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -35,7 +35,11 @@ export default function registerCommand(program: Command) {
     .option("-a, --app-location <path>", "the folder containing the source code of the front-end application", DEFAULT_CONFIG.appLocation)
     .option("-i, --api-location <path>", "the folder containing the source code of the API application", DEFAULT_CONFIG.apiLocation)
     .option("-O, --output-location <path>", "the folder containing the built source of the front-end application", DEFAULT_CONFIG.outputLocation)
-    .option("-D, --app-devserver-url <url>", "connect to the app dev server at this URL instead of using output location", DEFAULT_CONFIG.appDevserverUrl)
+    .option(
+      "-D, --app-devserver-url <url>",
+      "connect to the app dev server at this URL instead of using output location",
+      DEFAULT_CONFIG.appDevserverUrl
+    )
     .option("-is, --api-devserver-url <url>", "connect to the api server at this URL instead of using api location", DEFAULT_CONFIG.apiDevserverUrl)
     .option<number>("-j, --api-port <apiPort>", "the API server port passed to `func start`", parsePort, DEFAULT_CONFIG.apiPort)
     .option("-q, --host <host>", "the host address to use for the CLI dev server", DEFAULT_CONFIG.host)
@@ -112,6 +116,7 @@ swa start http://localhost:3000 --api-devserver-url http://localhost:7071
     );
 }
 
+export var isSSL: boolean = false;
 export async function start(options: SWACLIConfig) {
   // WARNING:
   // environment variables are populated using values provided by the user to the CLI.
@@ -270,6 +275,7 @@ export async function start(options: SWACLIConfig) {
   }
 
   if (ssl) {
+    isSSL = ssl;
     if (sslCert === undefined && sslKey === undefined) {
       logger.warn(`WARNING: Using built-in UNSIGNED certificate. DO NOT USE IN PRODUCTION!`);
       const pemFilepath = await getCertificate({

--- a/src/core/utils/net.spec.ts
+++ b/src/core/utils/net.spec.ts
@@ -318,5 +318,14 @@ describe("net utilities", () => {
     it("http url should be invalid", () => {
       expect(isHttpsUrl("http://foo.com")).toBeFalse();
     });
+    it("empty url should be invalid", () => {
+      expect(isHttpsUrl(undefined)).toBeFalse();
+    });
+    it("wrong Url should be invalid", () => {
+      expect(isHttpsUrl("foo.com")).toBeFalse();
+    });
+    it("url should not be case sensitive", () => {
+      expect(isHttpsUrl("HTTPS://foo.com")).toBeTrue();
+    });
   });
 });

--- a/src/core/utils/net.spec.ts
+++ b/src/core/utils/net.spec.ts
@@ -1,6 +1,6 @@
 jest.mock("../constants", () => {});
 import { logger } from "./logger";
-import { address, hostnameToIpAdress, parsePort, parseUrl, response } from "./net";
+import { address, hostnameToIpAdress, isHttpsUrl, parsePort, parseUrl, response } from "./net";
 
 describe("net utilities", () => {
   describe("response()", () => {
@@ -308,6 +308,15 @@ describe("net utilities", () => {
     });
     it("should parse the port given in the URL", () => {
       expect(parseUrl("https://foo.com:9999")).toMatchObject({ port: 9999 });
+    });
+  });
+
+  describe("isHttpsUrl()", () => {
+    it("https url should be valid", () => {
+      expect(isHttpsUrl("https://foo.com")).toBeTrue();
+    });
+    it("http url should be invalid", () => {
+      expect(isHttpsUrl("http://foo.com")).toBeFalse();
     });
   });
 });

--- a/src/core/utils/net.ts
+++ b/src/core/utils/net.ts
@@ -67,6 +67,24 @@ export function isHttpUrl(url: string | undefined) {
 }
 
 /**
+ * Check if a given URL string is a valid https URL.
+ * @param url The URL string to check.
+ * @returns True if the URL string is a valid https URL. False otherwise.
+ */
+export function isHttpsUrl(url: string | undefined) {
+  if (!url) {
+    return false;
+  }
+
+  try {
+    const uri = new URL(url);
+    return uri.protocol.startsWith("https");
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Checks if a given server is up and accepting connection.
  * @param url An HTTP URL.
  * @param timeout Maximum time in ms to wait before exiting with failure (1) code,

--- a/src/msha/server.ts
+++ b/src/msha/server.ts
@@ -6,19 +6,18 @@ import https from "https";
 import internalIp from "internal-ip";
 import net from "net";
 import open from "open";
-import { isSSL } from "../cli/commands/start";
 import { DEFAULT_CONFIG } from "../config";
-import { address, hostnameToIpAdress, isHttpUrl, logger, logRequest, registerProcessExit, validateDevServerConfig } from "../core";
+import { address, hostnameToIpAdress, isHttpUrl, isHttpsUrl, logger, logRequest, registerProcessExit, validateDevServerConfig } from "../core";
 import { HAS_API, IS_API_DEV_SERVER, IS_APP_DEV_SERVER, SWA_CLI_API_URI, SWA_CLI_APP_PROTOCOL } from "../core/constants";
 import { swaCLIEnv } from "../core/env";
 import { validateFunctionTriggers } from "./handlers/function.handler";
 import { handleUserConfig, onConnectionLost, requestMiddleware } from "./middlewares/request.middleware";
 
-const { SWA_CLI_PORT } = swaCLIEnv();
+const { SWA_CLI_PORT, SWA_CLI_APP_SSL } = swaCLIEnv();
 
 var proxyApp: any;
 
-if (isSSL) {
+if (SWA_CLI_APP_SSL === "true") {
   proxyApp = httpProxy.createProxyServer({
     autoRewrite: true,
     agent: new https.Agent({
@@ -29,7 +28,7 @@ if (isSSL) {
   if (isHttpUrl(SWA_CLI_API_URI())) {
     logger.warn(`Please make sure you want to hit the http proxy server.`);
   }
-} else {
+} else if (SWA_CLI_APP_SSL === "false") {
   proxyApp = httpProxy.createProxyServer({
     autoRewrite: true,
     agent: new http.Agent({
@@ -54,19 +53,6 @@ const httpsServerOptions: Pick<https.ServerOptions, "cert" | "key"> | null =
         key: DEFAULT_CONFIG.sslKey.startsWith("-----BEGIN") ? DEFAULT_CONFIG.sslKey : fs.readFileSync(DEFAULT_CONFIG.sslKey, "utf8"),
       }
     : null;
-
-function isHttpsUrl(url: string | undefined) {
-  if (!url) {
-    return false;
-  }
-
-  try {
-    const uri = new URL(url);
-    return uri.protocol.startsWith("https");
-  } catch {
-    return false;
-  }
-}
 
 function requestHandler(userConfig: SWAConfigFile | undefined) {
   return async function (req: http.IncomingMessage, res: http.ServerResponse) {


### PR DESCRIPTION
creating separate http and https agents depending on whether:
The user is hitting an http:// or https:// dev server.
The user is starting the CLI using --ssl or --no-ssl (by default)
Also, warning the user if:
They started the CLI using  --ssl but they are connecting to http:// dev server
They started the CLI with no SSL but they are connecting to https:// dev server