### PR TITLE
fix: token scope used when using cliendId/clientSecret auth (fix #541)

### DIFF
--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -10,7 +10,10 @@ import { authenticateWithAzureIdentity, listSubscriptions, listTenants } from ".
 import { ENV_FILENAME } from "../../core/constants";
 import { updateGitIgnore } from "../../core/git";
 import { chooseSubscription, chooseTenant } from "../../core/prompts";
+import { Environment } from "../../core/swa-cli-persistence-plugin/impl/azure-environment";
 const { readFile, writeFile } = fsPromises;
+
+const defaultScope = `${Environment.AzureCloud.resourceManagerEndpointUrl}/.default`;
 
 export function addSharedLoginOptionsToCommand(command: Command) {
   command
@@ -88,7 +91,7 @@ export async function login(options: SWACLIConfig): Promise<any> {
 
   credentialChain = await authenticateWithAzureIdentity({ tenantId, clientId, clientSecret }, options.useKeychain, options.clearCredentials);
 
-  if (await credentialChain.getToken("profile")) {
+  if (await credentialChain.getToken(defaultScope)) {
     logger.log(chalk.green(`✔ Successfully logged into Azure!`));
   }
 
@@ -115,7 +118,7 @@ async function setupProjectCredentials(options: SWACLIConfig, credentialChain: T
       // TODO: can we silently authenticate the user with the new tenant?
       credentialChain = await authenticateWithAzureIdentity({ tenantId, clientId, clientSecret }, options.useKeychain, true);
 
-      if (await credentialChain.getToken("profile")) {
+      if (await credentialChain.getToken(defaultScope)) {
         logger.log(chalk.green(`✔ Successfully logged into Azure tenant: ${tenantId}`));
       }
     }


### PR DESCRIPTION
#627 ended up not being enough: it fixed the auth part, but a new error occured when checking the token:

<img width="997" alt="image" src="https://user-images.githubusercontent.com/593151/211351353-5a166ee9-55f5-4eb7-8f95-a19964dcbcb2.png">

Not sure how I missed it the first time, maybe the token was cached during my initial tests so I missed it.

This PR use the default scope instead of "profile", which will work with all auth methods including clientId/clientSecret.