### PR TITLE
fix(init): allow to override apiDevserverUrl

### DIFF
--- a/src/cli/commands/init/init.spec.ts
+++ b/src/cli/commands/init/init.spec.ts
@@ -21,6 +21,7 @@ const defautResolvedPrompts = {
   apiBuildCommand: "npm run build:api",
   appDevserverCommand: "npm run dev",
   appDevserverUrl: "http://localhost:3000",
+  apiDevserverUrl: "http://localhost:4040",
   confirmOverwrite: true,
 };
 
@@ -149,6 +150,36 @@ describe("swa init", () => {
             \\"apiBuildCommand\\": \\"npm run build --if-present\\",
             \\"run\\": \\"npm run dev\\",
             \\"appDevserverUrl\\": \\"http://localhost:8080\\"
+          }
+        }
+      }"
+    `);
+  });
+
+  it("should detect frameworks and let user override config options", async () => {
+    mockFs({ src: mockFs.load("e2e/fixtures/static-node-ts") });
+    const promptsMock = jest.requireMock("prompts");
+    promptsMock.mockResolvedValue({
+      ...defautResolvedPrompts,
+      confirmSettings: false,
+    });
+
+    await init({ ...defaultCliConfig, configName: "test" });
+    const configFile = convertToUnixPaths(fs.readFileSync(defaultCliConfig.config, "utf-8"));
+
+    expect(configFile).toMatchInlineSnapshot(`
+      "{
+        \\"$schema\\": \\"https://aka.ms/azure/static-web-apps-cli/schema\\",
+        \\"configurations\\": {
+          \\"test\\": {
+            \\"appLocation\\": \\"./app\\",
+            \\"apiLocation\\": \\"./api\\",
+            \\"outputLocation\\": \\"./dist\\",
+            \\"appBuildCommand\\": \\"npm run build\\",
+            \\"apiBuildCommand\\": \\"npm run build:api\\",
+            \\"run\\": \\"npm run dev\\",
+            \\"appDevserverUrl\\": \\"http://localhost:3000\\",
+            \\"apiDevserverUrl\\": \\"http://localhost:4040\\"
           }
         }
       }"

--- a/src/cli/commands/init/init.ts
+++ b/src/cli/commands/init/init.ts
@@ -141,6 +141,7 @@ function convertToCliConfig(config: FrameworkConfig): SWACLIConfig {
     apiBuildCommand: config.apiBuildCommand,
     run: config.appDevserverCommand,
     appDevserverUrl: config.appDevserverUrl,
+    apiDevserverUrl: config.apiDevserverUrl,
   };
 }
 
@@ -198,8 +199,15 @@ async function promptConfigSettings(disablePrompts: boolean, detectedConfig: Fra
     {
       type: "text",
       name: "appDevserverUrl",
-      message: "What is your development server url (optional)",
+      message: "What's your app development server URL (optional)",
       initial: detectedConfig.appDevserverUrl,
+      format: trimValue,
+    },
+    {
+      type: "text",
+      name: "apiDevserverUrl",
+      message: "What's your API development server URL (optional)",
+      initial: detectedConfig.apiDevserverUrl,
       format: trimValue,
     },
   ]);
@@ -216,9 +224,5 @@ function printFrameworkConfig(config: FrameworkConfig) {
   logger.log(`- API build command: ${chalk.green(config.apiBuildCommand ?? "")}`);
   logger.log(`- App dev server command: ${chalk.green(config.appDevserverCommand ?? "")}`);
   logger.log(`- App dev server URL: ${chalk.green(config.appDevserverUrl ?? "")}\n`);
+  logger.log(`- API dev server URL: ${chalk.green(config.apiDevserverUrl ?? "")}\n`);
 }
-
-// function isEmptyFolder(path: string) {
-//   const files = fs.readdirSync(path);
-//   return files.length === 0;
-// }

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -276,6 +276,7 @@ declare type FrameworkConfig = GithubActionWorkflow & {
   apiBuildCommand?: string;
   appDevserverCommand?: string;
   appDevserverUrl?: string;
+  apiDevserverUrl?: string;
 };
 
 declare interface CoreToolsRelease {


### PR DESCRIPTION
Current when running `swa init` you cannot override the "apiDevserverUrl" option, which is useful when your backend isn't using provided functions, but for example using a Container App (which maps locally to using a container).

This PR adds the missing prompt for this option along with a unit test.