### PR TITLE
feat: telemetry collection basic changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
         "@azure/arm-subscriptions": "^5.0.0",
         "@azure/identity": "^3.1.2",
         "@azure/msal-common": "^6.2.0",
-        "applicationinsights": "2.4.1",
         "ajv": "^8.11.0",
         "ajv-draft-04": "^1.0.0",
+        "applicationinsights": "2.4.1",
         "chalk": "^4.1.2",
         "cli-progress": "^3.10.0",
         "commander": "^9.2.0",
@@ -165,9 +165,9 @@
       }
     },
     "node_modules/@azure/core-auth": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.3.2.tgz",
-      "integrity": "sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.4.0.tgz",
+      "integrity": "sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "tslib": "^2.2.0"
@@ -231,23 +231,44 @@
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.9.0.tgz",
-      "integrity": "sha512-uvM3mY+Vegk0F2r4Eh0yPdsXTUyafTQkeX0USnz1Eyangxm2Bib0w0wkJVZW8fpks7Lcv0ztIdCFTrN7H8uptg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.10.1.tgz",
+      "integrity": "sha512-Kji9k6TOFRDB5ZMTw8qUf2IJ+CeJtsuMdAHox9eqpTf1cefiNMpzrfnF6sINEBZJsaVaWgQ0o48B6kcUH68niA==",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.3.0",
+        "@azure/core-auth": "^1.4.0",
         "@azure/core-tracing": "^1.0.1",
         "@azure/core-util": "^1.0.0",
         "@azure/logger": "^1.0.0",
         "form-data": "^4.0.0",
-        "http-proxy-agent": "^4.0.1",
+        "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "tslib": "^2.2.0",
         "uuid": "^8.3.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline/node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@azure/core-tracing": {
@@ -345,12 +366,12 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
-      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.15.0.tgz",
+      "integrity": "sha512-fwC5M0c8pxOAzmScPbpx7j28YVTDebUaizlVF7bR0xvlU0r3VWW5OobCcr9ybqKS6wGyO7u4EhXJS9rjRWAuwA==",
       "dependencies": {
-        "@azure/msal-common": "^9.0.1",
-        "jsonwebtoken": "^8.5.1",
+        "@azure/msal-common": "^10.0.0",
+        "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
       "engines": {
@@ -358,9 +379,9 @@
       }
     },
     "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.0.1.tgz",
-      "integrity": "sha512-eNNHIW/cwPTZDWs9KtYgb1X6gtQ+cC+FGX2YN+t4AUVsBdUbqlMTnUs6/c/VBxC2AAGIhgLREuNnO3F66AN2zQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-10.0.0.tgz",
+      "integrity": "sha512-/LghpT93jsZLy55QzTsRZWMx6R1Mjc1Aktwps8sKSGE3WbrGwbSsh2uhDlpl6FMcKChYjJ0ochThWwwOodrQNg==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -1665,6 +1686,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@microsoft/applicationinsights-web-snippet": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.0.1.tgz",
+      "integrity": "sha512-2IHAOaLauc8qaAitvWS+U931T+ze+7MNWrDHY47IENP5y2UA0vqJDu67kWZDdpCN1fFC77sfgfB+HV7SrKshnQ=="
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1838,6 +1864,59 @@
       "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-6/qon6tw2I8ZaJnHAQUUn4BqhTbTNRS0WP8/bA0ynaX+Uzp/DDbd0NS0Cq6TMlh8+mrlsyqDE7mO50nmv2Yvlg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.9.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.9.1.tgz",
+      "integrity": "sha512-VqBGbnAfubI+l+yrtYxeLyOoL358JK57btPMJDd3TCOV3mV5TNBmzvOfmesM4NeTyXuGJByd3XvOHvFezLn3rQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.9.1",
+        "@opentelemetry/semantic-conventions": "1.9.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.9.1.tgz",
+      "integrity": "sha512-Y9gC5M1efhDLYHeeo2MWcDDMmR40z6QpqcWnPCm4Dmh+RHAMf4dnEBBntIe1dDpor686kyU6JV1D29ih1lZpsQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.9.1",
+        "@opentelemetry/resources": "1.9.1",
+        "@opentelemetry/semantic-conventions": "1.9.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.1.tgz",
+      "integrity": "sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@semantic-release/changelog": {
@@ -2022,9 +2101,9 @@
       }
     },
     "node_modules/@sideway/formula": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
     },
     "node_modules/@sideway/pinpoint": {
       "version": "2.0.0",
@@ -2072,6 +2151,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -2799,6 +2879,35 @@
       "resolved": "https://registry.npmjs.org/application-config-path/-/application-config-path-0.1.0.tgz",
       "integrity": "sha512-lljTpVvFteShrHuKRvweZfa9o/Nc34Y8r5/1Lqh/yyKaspRT2J3fkEiSSk1YLG8ZSVyU7yHysRy9zcDDS2aH1Q=="
     },
+    "node_modules/applicationinsights": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.4.1.tgz",
+      "integrity": "sha512-0n0Ikd0gzSm460xm+M0UTWIwXrhrH/0bqfZatcJjYObWyefxfAxapGEyNnSGd1Tg90neHz+Yhf+Ff/zgvPiQYA==",
+      "dependencies": {
+        "@azure/core-auth": "^1.4.0",
+        "@azure/core-rest-pipeline": "^1.10.0",
+        "@microsoft/applicationinsights-web-snippet": "^1.0.1",
+        "@opentelemetry/api": "^1.0.4",
+        "@opentelemetry/core": "^1.0.1",
+        "@opentelemetry/sdk-trace-base": "^1.0.1",
+        "@opentelemetry/semantic-conventions": "^1.0.1",
+        "cls-hooked": "^4.2.2",
+        "continuation-local-storage": "^3.2.1",
+        "diagnostic-channel": "1.1.0",
+        "diagnostic-channel-publishers": "1.0.5"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "applicationinsights-native-metrics": "*"
+      },
+      "peerDependenciesMeta": {
+        "applicationinsights-native-metrics": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/arch": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
@@ -2902,6 +3011,37 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
       "dev": true
+    },
+    "node_modules/async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "dependencies": {
+        "stack-chain": "^1.3.7"
+      },
+      "engines": {
+        "node": "^4.7 || >=6.9 || >=7.3"
+      }
+    },
+    "node_modules/async-listener": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
+      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
+      "dependencies": {
+        "semver": "^5.3.0",
+        "shimmer": "^1.1.0"
+      },
+      "engines": {
+        "node": "<=0.11.8 || >0.11.10"
+      }
+    },
+    "node_modules/async-listener/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -3700,6 +3840,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "dependencies": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      },
+      "engines": {
+        "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
+      }
+    },
+    "node_modules/cls-hooked/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3850,6 +4011,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/continuation-local-storage": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+      "dependencies": {
+        "async-listener": "^0.6.0",
+        "emitter-listener": "^1.1.1"
+      }
+    },
     "node_modules/conventional-changelog-angular": {
       "version": "5.0.13",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
@@ -3952,9 +4122,9 @@
       }
     },
     "node_modules/cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
     },
     "node_modules/core-util-is": {
@@ -4570,6 +4740,30 @@
         "wrappy": "1"
       }
     },
+    "node_modules/diagnostic-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.0.tgz",
+      "integrity": "sha512-fwujyMe1gj6rk6dYi9hMZm0c8Mz8NDMVl2LB4iaYh3+LIAThZC8RKFGXWG0IML2OxAit/ZFRgZhMkhQ3d/bobQ==",
+      "dependencies": {
+        "semver": "^5.3.0"
+      }
+    },
+    "node_modules/diagnostic-channel-publishers": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.5.tgz",
+      "integrity": "sha512-dJwUS0915pkjjimPJVDnS/QQHsH0aOYhnZsLJdnZIMOrB+csj8RnZhWTuwnm8R5v3Z7OZs+ksv5luC14DGB7eg==",
+      "peerDependencies": {
+        "diagnostic-channel": "*"
+      }
+    },
+    "node_modules/diagnostic-channel/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -4699,6 +4893,14 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.180.tgz",
       "integrity": "sha512-7at5ash3FD9U5gPa3/wPr6OdiZd/zBjvDZaaHBpcqFOFUhZiWnb7stkqk8xUFL9H9nk7Yok5vCCNK8wyC/+f8A==",
       "dev": true
+    },
+    "node_modules/emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "dependencies": {
+        "shimmer": "^1.2.0"
+      }
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -5795,9 +5997,9 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -5831,6 +6033,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
       "dependencies": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -7426,9 +7629,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -7475,24 +7678,18 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
       "dependencies": {
         "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
+        "lodash": "^4.17.21",
         "ms": "^2.1.1",
-        "semver": "^5.6.0"
+        "semver": "^7.3.8"
       },
       "engines": {
-        "node": ">=4",
-        "npm": ">=1.4.28"
+        "node": ">=12",
+        "npm": ">=6"
       }
     },
     "node_modules/jsonwebtoken/node_modules/jwa": {
@@ -7515,11 +7712,17 @@
       }
     },
     "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jsprim": {
@@ -7915,41 +8118,23 @@
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
       "dev": true
     },
-    "node_modules/lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
-    },
-    "node_modules/lodash.isboolean": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
-    },
-    "node_modules/lodash.isinteger": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
-    },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
       "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
       "dev": true
     },
-    "node_modules/lodash.isnumber": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
-    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -7960,7 +8145,8 @@
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true
     },
     "node_modules/lodash.uniqby": {
       "version": "4.7.0",
@@ -12588,6 +12774,11 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
       "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
     },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -12907,6 +13098,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug=="
     },
     "node_modules/stack-utils": {
       "version": "2.0.5",
@@ -14368,9 +14564,9 @@
       }
     },
     "@azure/core-auth": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.3.2.tgz",
-      "integrity": "sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.4.0.tgz",
+      "integrity": "sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
         "tslib": "^2.2.0"
@@ -14421,20 +14617,37 @@
       }
     },
     "@azure/core-rest-pipeline": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.9.0.tgz",
-      "integrity": "sha512-uvM3mY+Vegk0F2r4Eh0yPdsXTUyafTQkeX0USnz1Eyangxm2Bib0w0wkJVZW8fpks7Lcv0ztIdCFTrN7H8uptg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.10.1.tgz",
+      "integrity": "sha512-Kji9k6TOFRDB5ZMTw8qUf2IJ+CeJtsuMdAHox9eqpTf1cefiNMpzrfnF6sINEBZJsaVaWgQ0o48B6kcUH68niA==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.3.0",
+        "@azure/core-auth": "^1.4.0",
         "@azure/core-tracing": "^1.0.1",
         "@azure/core-util": "^1.0.0",
         "@azure/logger": "^1.0.0",
         "form-data": "^4.0.0",
-        "http-proxy-agent": "^4.0.1",
+        "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "tslib": "^2.2.0",
         "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "@tootallnate/once": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+          "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+        },
+        "http-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+          "requires": {
+            "@tootallnate/once": "2",
+            "agent-base": "6",
+            "debug": "4"
+          }
+        }
       }
     },
     "@azure/core-tracing": {
@@ -14512,19 +14725,19 @@
       "integrity": "sha512-WZdgq9f9O8cbxGzdRwLLMM5xjmLJ2mdtuzgXeiGxIRkVVlJ9nZ6sWnDFKa2TX8j72UXD1IfL0p/RYNoTXYoGfg=="
     },
     "@azure/msal-node": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
-      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.15.0.tgz",
+      "integrity": "sha512-fwC5M0c8pxOAzmScPbpx7j28YVTDebUaizlVF7bR0xvlU0r3VWW5OobCcr9ybqKS6wGyO7u4EhXJS9rjRWAuwA==",
       "requires": {
-        "@azure/msal-common": "^9.0.1",
-        "jsonwebtoken": "^8.5.1",
+        "@azure/msal-common": "^10.0.0",
+        "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
       "dependencies": {
         "@azure/msal-common": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.0.1.tgz",
-          "integrity": "sha512-eNNHIW/cwPTZDWs9KtYgb1X6gtQ+cC+FGX2YN+t4AUVsBdUbqlMTnUs6/c/VBxC2AAGIhgLREuNnO3F66AN2zQ=="
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-10.0.0.tgz",
+          "integrity": "sha512-/LghpT93jsZLy55QzTsRZWMx6R1Mjc1Aktwps8sKSGE3WbrGwbSsh2uhDlpl6FMcKChYjJ0ochThWwwOodrQNg=="
         }
       }
     },
@@ -15552,6 +15765,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@microsoft/applicationinsights-web-snippet": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.0.1.tgz",
+      "integrity": "sha512-2IHAOaLauc8qaAitvWS+U931T+ze+7MNWrDHY47IENP5y2UA0vqJDu67kWZDdpCN1fFC77sfgfB+HV7SrKshnQ=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -15707,6 +15925,38 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
       "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ=="
     },
+    "@opentelemetry/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-6/qon6tw2I8ZaJnHAQUUn4BqhTbTNRS0WP8/bA0ynaX+Uzp/DDbd0NS0Cq6TMlh8+mrlsyqDE7mO50nmv2Yvlg==",
+      "requires": {
+        "@opentelemetry/semantic-conventions": "1.9.1"
+      }
+    },
+    "@opentelemetry/resources": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.9.1.tgz",
+      "integrity": "sha512-VqBGbnAfubI+l+yrtYxeLyOoL358JK57btPMJDd3TCOV3mV5TNBmzvOfmesM4NeTyXuGJByd3XvOHvFezLn3rQ==",
+      "requires": {
+        "@opentelemetry/core": "1.9.1",
+        "@opentelemetry/semantic-conventions": "1.9.1"
+      }
+    },
+    "@opentelemetry/sdk-trace-base": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.9.1.tgz",
+      "integrity": "sha512-Y9gC5M1efhDLYHeeo2MWcDDMmR40z6QpqcWnPCm4Dmh+RHAMf4dnEBBntIe1dDpor686kyU6JV1D29ih1lZpsQ==",
+      "requires": {
+        "@opentelemetry/core": "1.9.1",
+        "@opentelemetry/resources": "1.9.1",
+        "@opentelemetry/semantic-conventions": "1.9.1"
+      }
+    },
+    "@opentelemetry/semantic-conventions": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.1.tgz",
+      "integrity": "sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg=="
+    },
     "@semantic-release/changelog": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.1.tgz",
@@ -15851,9 +16101,9 @@
       }
     },
     "@sideway/formula": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
     },
     "@sideway/pinpoint": {
       "version": "2.0.0",
@@ -15894,7 +16144,8 @@
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
     },
     "@tsconfig/node10": {
       "version": "1.0.9",
@@ -16535,6 +16786,24 @@
       "resolved": "https://registry.npmjs.org/application-config-path/-/application-config-path-0.1.0.tgz",
       "integrity": "sha512-lljTpVvFteShrHuKRvweZfa9o/Nc34Y8r5/1Lqh/yyKaspRT2J3fkEiSSk1YLG8ZSVyU7yHysRy9zcDDS2aH1Q=="
     },
+    "applicationinsights": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.4.1.tgz",
+      "integrity": "sha512-0n0Ikd0gzSm460xm+M0UTWIwXrhrH/0bqfZatcJjYObWyefxfAxapGEyNnSGd1Tg90neHz+Yhf+Ff/zgvPiQYA==",
+      "requires": {
+        "@azure/core-auth": "^1.4.0",
+        "@azure/core-rest-pipeline": "^1.10.0",
+        "@microsoft/applicationinsights-web-snippet": "^1.0.1",
+        "@opentelemetry/api": "^1.0.4",
+        "@opentelemetry/core": "^1.0.1",
+        "@opentelemetry/sdk-trace-base": "^1.0.1",
+        "@opentelemetry/semantic-conventions": "^1.0.1",
+        "cls-hooked": "^4.2.2",
+        "continuation-local-storage": "^3.2.1",
+        "diagnostic-channel": "1.1.0",
+        "diagnostic-channel-publishers": "1.0.5"
+      }
+    },
     "arch": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
@@ -16612,6 +16881,30 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
       "dev": true
+    },
+    "async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "requires": {
+        "stack-chain": "^1.3.7"
+      }
+    },
+    "async-listener": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
+      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
+      "requires": {
+        "semver": "^5.3.0",
+        "shimmer": "^1.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -17192,6 +17485,23 @@
         }
       }
     },
+    "cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "requires": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -17313,6 +17623,15 @@
         "xdg-basedir": "^4.0.0"
       }
     },
+    "continuation-local-storage": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+      "requires": {
+        "async-listener": "^0.6.0",
+        "emitter-listener": "^1.1.1"
+      }
+    },
     "conventional-changelog-angular": {
       "version": "5.0.13",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
@@ -17395,9 +17714,9 @@
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
     },
     "cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
     },
     "core-util-is": {
@@ -17877,6 +18196,27 @@
         "wrappy": "1"
       }
     },
+    "diagnostic-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.0.tgz",
+      "integrity": "sha512-fwujyMe1gj6rk6dYi9hMZm0c8Mz8NDMVl2LB4iaYh3+LIAThZC8RKFGXWG0IML2OxAit/ZFRgZhMkhQ3d/bobQ==",
+      "requires": {
+        "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "diagnostic-channel-publishers": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.5.tgz",
+      "integrity": "sha512-dJwUS0915pkjjimPJVDnS/QQHsH0aOYhnZsLJdnZIMOrB+csj8RnZhWTuwnm8R5v3Z7OZs+ksv5luC14DGB7eg==",
+      "requires": {}
+    },
     "didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -17987,6 +18327,14 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.180.tgz",
       "integrity": "sha512-7at5ash3FD9U5gPa3/wPr6OdiZd/zBjvDZaaHBpcqFOFUhZiWnb7stkqk8xUFL9H9nk7Yok5vCCNK8wyC/+f8A==",
       "dev": true
+    },
+    "emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "requires": {
+        "shimmer": "^1.2.0"
+      }
     },
     "emittery": {
       "version": "0.8.1",
@@ -18809,9 +19157,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-errors": {
       "version": "2.0.0",
@@ -18839,6 +19187,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
       "requires": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -20047,9 +20396,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsonfile": {
@@ -20079,20 +20428,14 @@
       }
     },
     "jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
       "requires": {
         "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
+        "lodash": "^4.17.21",
         "ms": "^2.1.1",
-        "semver": "^5.6.0"
+        "semver": "^7.3.8"
       },
       "dependencies": {
         "jwa": {
@@ -20115,9 +20458,12 @@
           }
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -20415,41 +20761,23 @@
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
       "dev": true
     },
-    "lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
-    },
-    "lodash.isboolean": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
-    },
-    "lodash.isinteger": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
-    },
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
       "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
       "dev": true
     },
-    "lodash.isnumber": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
-    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -20460,7 +20788,8 @@
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true
     },
     "lodash.uniqby": {
       "version": "4.7.0",
@@ -23782,6 +24111,11 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
       "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
     },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -24026,6 +24360,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
+    },
+    "stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug=="
     },
     "stack-utils": {
       "version": "2.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@azure/arm-subscriptions": "^5.0.0",
         "@azure/identity": "^3.1.2",
         "@azure/msal-common": "^6.2.0",
+        "applicationinsights": "2.4.1",
         "ajv": "^8.11.0",
         "ajv-draft-04": "^1.0.0",
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@azure/arm-subscriptions": "^5.0.0",
     "@azure/identity": "^3.1.2",
     "@azure/msal-common": "^6.2.0",
+    "applicationinsights": "2.4.1",
     "ajv": "^8.11.0",
     "ajv-draft-04": "^1.0.0",
     "chalk": "^4.1.2",

--- a/src/cli/commands/login/login.ts
+++ b/src/cli/commands/login/login.ts
@@ -9,6 +9,8 @@ import { ENV_FILENAME } from "../../../core/constants";
 import { updateGitIgnore } from "../../../core/git";
 import { chooseSubscription, chooseTenant } from "../../../core/prompts";
 import { Environment } from "../../../core/swa-cli-persistence-plugin/impl/azure-environment";
+import { collectTelemetryEvent } from "../../../core/telemetry/utils";
+
 const { readFile, writeFile } = fsPromises;
 
 const defaultScope = `${Environment.AzureCloud.resourceManagerEndpointUrl}/.default`;
@@ -16,6 +18,7 @@ const defaultScope = `${Environment.AzureCloud.resourceManagerEndpointUrl}/.defa
 export async function loginCommand(options: SWACLIConfig) {
   try {
     const { credentialChain, subscriptionId } = await login(options);
+    collectTelemetryEvent("login", { subscriptionId: subscriptionId });
 
     if (credentialChain && subscriptionId) {
       logger.log(chalk.green(`✔ Successfully setup project!`));

--- a/src/cli/commands/login/login.ts
+++ b/src/cli/commands/login/login.ts
@@ -9,8 +9,6 @@ import { ENV_FILENAME } from "../../../core/constants";
 import { updateGitIgnore } from "../../../core/git";
 import { chooseSubscription, chooseTenant } from "../../../core/prompts";
 import { Environment } from "../../../core/swa-cli-persistence-plugin/impl/azure-environment";
-import { collectTelemetryEvent } from "../../../core/telemetry/utils";
-
 const { readFile, writeFile } = fsPromises;
 
 const defaultScope = `${Environment.AzureCloud.resourceManagerEndpointUrl}/.default`;
@@ -18,7 +16,6 @@ const defaultScope = `${Environment.AzureCloud.resourceManagerEndpointUrl}/.defa
 export async function loginCommand(options: SWACLIConfig) {
   try {
     const { credentialChain, subscriptionId } = await login(options);
-    collectTelemetryEvent("login", { subscriptionId: subscriptionId });
 
     if (credentialChain && subscriptionId) {
       logger.log(chalk.green(`✔ Successfully setup project!`));

--- a/src/core/telemetry/baseTelemetryReporter.ts
+++ b/src/core/telemetry/baseTelemetryReporter.ts
@@ -1,0 +1,71 @@
+import type { TelemetryEventMeasurements, RawTelemetryEventProperties, TelemetryEventProperties } from "./telemetryReporterTypes";
+import { BaseTelemetrySender } from "./baseTelemetrySender";
+
+export interface SenderData {
+  properties?: RawTelemetryEventProperties;
+  measurements?: TelemetryEventMeasurements;
+}
+
+export class BaseTelemetryReporter {
+  constructor(private telemetrySender: BaseTelemetrySender) {
+    this.telemetrySender.instantiateSender();
+  }
+  /**
+   * Internal function which logs telemetry events and takes extra options.
+   * @param eventName The name of the event
+   * @param properties The properties of the event
+   * @param measurements The measurements (numeric values) to send with the event
+   */
+  private internalSendTelemetryEvent(
+    eventName: string,
+    properties: TelemetryEventProperties | undefined,
+    measurements: TelemetryEventMeasurements | undefined
+  ): void {
+    this.telemetrySender.sendEventData(eventName, { properties, measurements });
+  }
+
+  /**
+   * Given an event name, some properties, and measurements sends a telemetry event.
+   * Properties are sanitized on best-effort basis to remove sensitive data prior to sending.
+   * @param eventName The name of the event
+   * @param properties The properties to send with the event
+   * @param measurements The measurements (numeric values) to send with the event
+   */
+  public sendTelemetryEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void {
+    this.internalSendTelemetryEvent(eventName, properties, measurements);
+  }
+
+  /**
+   * Given an event name, some properties, and measurements sends an error event
+   * @param eventName The name of the event
+   * @param properties The properties to send with the event
+   * @param measurements The measurements (numeric values) to send with the event
+   */
+  public sendTelemetryErrorEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void {
+    this.internalSendTelemetryEvent(eventName, properties, measurements);
+  }
+
+  /**
+   * Internal function which logs telemetry exceptions and takes extra options
+   * @param error: The error to send
+   * @param properties The properties of the event
+   * @param measurements The measurements (numeric values) to send with the event
+   */
+  private internalSendTelemetryException(
+    error: Error,
+    properties: TelemetryEventProperties | undefined,
+    measurements: TelemetryEventMeasurements | undefined
+  ): void {
+    this.telemetrySender.sendErrorData(error, { properties, measurements });
+  }
+
+  /**
+   * Given an error, properties, and measurements. Sends an exception event
+   * @param error The error to send
+   * @param properties The properties to send with the event
+   * @param measurements The measurements (numeric values) to send with the event
+   */
+  public sendTelemetryException(error: Error, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void {
+    this.internalSendTelemetryException(error, properties, measurements);
+  }
+}

--- a/src/core/telemetry/baseTelemetryReporter.ts
+++ b/src/core/telemetry/baseTelemetryReporter.ts
@@ -52,11 +52,11 @@ export class BaseTelemetryReporter {
    * @param measurements The measurements (numeric values) to send with the event
    */
   private internalSendTelemetryException(
-    error: Error,
+    exception: Error,
     properties: TelemetryEventProperties | undefined,
     measurements: TelemetryEventMeasurements | undefined
   ): void {
-    this.telemetrySender.sendErrorData(error, { properties, measurements });
+    this.telemetrySender.sendExceptionData(exception, { properties, measurements });
   }
 
   /**
@@ -65,7 +65,7 @@ export class BaseTelemetryReporter {
    * @param properties The properties to send with the event
    * @param measurements The measurements (numeric values) to send with the event
    */
-  public sendTelemetryException(error: Error, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void {
-    this.internalSendTelemetryException(error, properties, measurements);
+  public sendTelemetryException(exception: Error, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void {
+    this.internalSendTelemetryException(exception, properties, measurements);
   }
 }

--- a/src/core/telemetry/baseTelemetryReporter.ts
+++ b/src/core/telemetry/baseTelemetryReporter.ts
@@ -10,19 +10,6 @@ export class BaseTelemetryReporter {
   constructor(private telemetrySender: BaseTelemetrySender) {
     this.telemetrySender.instantiateSender();
   }
-  /**
-   * Internal function which logs telemetry events and takes extra options.
-   * @param eventName The name of the event
-   * @param properties The properties of the event
-   * @param measurements The measurements (numeric values) to send with the event
-   */
-  private internalSendTelemetryEvent(
-    eventName: string,
-    properties: TelemetryEventProperties | undefined,
-    measurements: TelemetryEventMeasurements | undefined
-  ): void {
-    this.telemetrySender.sendEventData(eventName, { properties, measurements });
-  }
 
   /**
    * Given an event name, some properties, and measurements sends a telemetry event.
@@ -46,6 +33,30 @@ export class BaseTelemetryReporter {
   }
 
   /**
+   * Given an error, properties, and measurements. Sends an exception event
+   * @param error The error to send
+   * @param properties The properties to send with the event
+   * @param measurements The measurements (numeric values) to send with the event
+   */
+  public sendTelemetryException(exception: Error, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void {
+    this.internalSendTelemetryException(exception, properties, measurements);
+  }
+
+  /**
+   * Internal function which logs telemetry events and takes extra options.
+   * @param eventName The name of the event
+   * @param properties The properties of the event
+   * @param measurements The measurements (numeric values) to send with the event
+   */
+  private internalSendTelemetryEvent(
+    eventName: string,
+    properties: TelemetryEventProperties | undefined,
+    measurements: TelemetryEventMeasurements | undefined
+  ): void {
+    this.telemetrySender.sendEventData(eventName, { properties, measurements });
+  }
+
+  /**
    * Internal function which logs telemetry exceptions and takes extra options
    * @param error: The error to send
    * @param properties The properties of the event
@@ -57,15 +68,5 @@ export class BaseTelemetryReporter {
     measurements: TelemetryEventMeasurements | undefined
   ): void {
     this.telemetrySender.sendExceptionData(exception, { properties, measurements });
-  }
-
-  /**
-   * Given an error, properties, and measurements. Sends an exception event
-   * @param error The error to send
-   * @param properties The properties to send with the event
-   * @param measurements The measurements (numeric values) to send with the event
-   */
-  public sendTelemetryException(exception: Error, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void {
-    this.internalSendTelemetryException(exception, properties, measurements);
   }
 }

--- a/src/core/telemetry/baseTelemetrySender.ts
+++ b/src/core/telemetry/baseTelemetrySender.ts
@@ -2,7 +2,7 @@ import { SenderData } from "./baseTelemetryReporter";
 
 export interface BaseTelemetryClient {
   logEvent(eventName: string, data?: SenderData): void;
-  logError(exceptionName: Error, data?: SenderData): void;
+  logException(exceptionName: Error, data?: SenderData): void;
   flush(): void | Promise<void>;
 }
 
@@ -54,14 +54,14 @@ export class BaseTelemetrySender implements TelemetrySender {
    * @param exception The exception to collect
    * @param data Data associated with the exception
    */
-  sendErrorData(exception: Error, data?: SenderData): void {
+  sendExceptionData(exception: Error, data?: SenderData): void {
     if (!this._telemetryClient) {
       if (this._instantiationStatus !== InstantiationStatus.INSTANTIATED) {
         this._exceptionQueue.push({ exception, data });
       }
       return;
     }
-    this._telemetryClient.logError(exception, data);
+    this._telemetryClient.logException(exception, data);
   }
 
   /**
@@ -81,7 +81,7 @@ export class BaseTelemetrySender implements TelemetrySender {
   private _flushQueues(): void {
     this._eventQueue.forEach(({ eventName, data }) => this.sendEventData(eventName, data));
     this._eventQueue = [];
-    this._exceptionQueue.forEach(({ exception, data }) => this.sendErrorData(exception, data));
+    this._exceptionQueue.forEach(({ exception, data }) => this.sendExceptionData(exception, data));
     this._exceptionQueue = [];
   }
 

--- a/src/core/telemetry/baseTelemetrySender.ts
+++ b/src/core/telemetry/baseTelemetrySender.ts
@@ -76,16 +76,6 @@ export class BaseTelemetrySender implements TelemetrySender {
   }
 
   /**
-   * Flushes the queued events that existed before the client was instantiated
-   */
-  private _flushQueues(): void {
-    this._eventQueue.forEach(({ eventName, data }) => this.sendEventData(eventName, data));
-    this._eventQueue = [];
-    this._exceptionQueue.forEach(({ exception, data }) => this.sendExceptionData(exception, data));
-    this._exceptionQueue = [];
-  }
-
-  /**
    * Instantiates the telemetry client to make the sender "active"
    */
   instantiateSender(): void {
@@ -103,5 +93,15 @@ export class BaseTelemetrySender implements TelemetrySender {
       .catch((err) => {
         throw new Error("Failed to instantiate app insights client factory!\n" + err.message);
       });
+  }
+
+  /**
+   * Flushes the queued events that existed before the client was instantiated
+   */
+  private _flushQueues(): void {
+    this._eventQueue.forEach(({ eventName, data }) => this.sendEventData(eventName, data));
+    this._eventQueue = [];
+    this._exceptionQueue.forEach(({ exception, data }) => this.sendExceptionData(exception, data));
+    this._exceptionQueue = [];
   }
 }

--- a/src/core/telemetry/baseTelemetrySender.ts
+++ b/src/core/telemetry/baseTelemetrySender.ts
@@ -1,0 +1,107 @@
+import { SenderData } from "./baseTelemetryReporter";
+
+export interface BaseTelemetryClient {
+  logEvent(eventName: string, data?: SenderData): void;
+  logError(exceptionName: Error, data?: SenderData): void;
+  flush(): void | Promise<void>;
+}
+
+enum InstantiationStatus {
+  NOT_INSTANTIATED,
+  INSTANTIATING,
+  INSTANTIATED,
+}
+
+export interface TelemetrySender {
+  instantiateSender(): void;
+}
+
+export class BaseTelemetrySender implements TelemetrySender {
+  // Whether or not the client has been instantiated
+  private _instantiationStatus: InstantiationStatus = InstantiationStatus.NOT_INSTANTIATED;
+  private _telemetryClient: BaseTelemetryClient | undefined;
+
+  // Queues used to store events until the sender is ready
+  private _eventQueue: Array<{ eventName: string; data: SenderData | undefined }> = [];
+  private _exceptionQueue: Array<{ exception: Error; data: SenderData | undefined }> = [];
+
+  // Necessary information to create a telemetry client
+  private _clientFactory: (key: string) => Promise<BaseTelemetryClient>;
+  private _key: string;
+
+  constructor(key: string, clientFactory: (key: string) => Promise<BaseTelemetryClient>) {
+    this._clientFactory = clientFactory;
+    this._key = key;
+  }
+
+  /**
+   * Sends the event to the passed in telemetry client
+   * @param eventName The name of the event to log
+   * @param data The data contained in the event
+   */
+  sendEventData(eventName: string, data?: SenderData): void {
+    if (!this._telemetryClient) {
+      if (this._instantiationStatus !== InstantiationStatus.INSTANTIATED) {
+        this._eventQueue.push({ eventName, data });
+      }
+      return;
+    }
+    this._telemetryClient.logEvent(eventName, data);
+  }
+
+  /**
+   * Sends an exception to the passed in telemetry client
+   * @param exception The exception to collect
+   * @param data Data associated with the exception
+   */
+  sendErrorData(exception: Error, data?: SenderData): void {
+    if (!this._telemetryClient) {
+      if (this._instantiationStatus !== InstantiationStatus.INSTANTIATED) {
+        this._exceptionQueue.push({ exception, data });
+      }
+      return;
+    }
+    this._telemetryClient.logError(exception, data);
+  }
+
+  /**
+   * Flushes the buffered telemetry data
+   */
+  async flush(): Promise<void> {
+    if (this._telemetryClient) {
+      await this._telemetryClient.flush();
+      this._telemetryClient = undefined;
+    }
+    return;
+  }
+
+  /**
+   * Flushes the queued events that existed before the client was instantiated
+   */
+  private _flushQueues(): void {
+    this._eventQueue.forEach(({ eventName, data }) => this.sendEventData(eventName, data));
+    this._eventQueue = [];
+    this._exceptionQueue.forEach(({ exception, data }) => this.sendErrorData(exception, data));
+    this._exceptionQueue = [];
+  }
+
+  /**
+   * Instantiates the telemetry client to make the sender "active"
+   */
+  instantiateSender(): void {
+    if (this._instantiationStatus !== InstantiationStatus.NOT_INSTANTIATED) {
+      return;
+    }
+    this._instantiationStatus = InstantiationStatus.INSTANTIATING;
+    // Call the client factory to get the client and then let it know it's instantiated
+    this._clientFactory(this._key)
+      .then((client) => {
+        this._telemetryClient = client;
+        this._instantiationStatus = InstantiationStatus.INSTANTIATED;
+        this._flushQueues();
+      })
+      .catch((err) => {
+        throw new Error("Failed to instantiate app insights client factory!\n" + err.message);
+      });
+  }
+}

--- a/src/core/telemetry/telemetryReporter.ts
+++ b/src/core/telemetry/telemetryReporter.ts
@@ -1,0 +1,84 @@
+import type { TelemetryClient } from "applicationinsights";
+import { SenderData, BaseTelemetryReporter } from "./baseTelemetryReporter";
+import { BaseTelemetrySender, BaseTelemetryClient } from "./baseTelemetrySender";
+/**
+ * A factory function which creates a telemetry client to be used by an sender to send telemetry in a node application.
+ *
+ * @param key The app insights key
+ *
+ * @returns A promise which resolves to the telemetry client or rejects upon error
+ */
+const appInsightsClientFactory = async (key: string): Promise<BaseTelemetryClient> => {
+  let appInsightsClient: TelemetryClient | undefined;
+  try {
+    const appInsights = await import("applicationinsights");
+    //check if another instance is already initialized
+    if (appInsights.defaultClient) {
+      appInsightsClient = new appInsights.TelemetryClient(key);
+      appInsightsClient.channel.setUseDiskRetryCaching(true);
+    } else {
+      console.log("setup");
+      appInsights
+        .setup(key)
+        .setAutoCollectRequests(false)
+        .setAutoCollectPerformance(false)
+        .setAutoCollectExceptions(false)
+        .setAutoCollectDependencies(false)
+        .setAutoDependencyCorrelation(false)
+        .setAutoCollectConsole(true, true)
+        .setAutoCollectHeartbeat(false)
+        .setUseDiskRetryCaching(true)
+        .start();
+      appInsightsClient = appInsights.defaultClient;
+    }
+    console.log("created");
+  } catch (e: any) {
+    return Promise.reject("Failed to initialize app insights!\n" + e.message);
+  }
+
+  const telemetryClient: BaseTelemetryClient = {
+    logEvent: (eventName: string, data?: SenderData) => {
+      try {
+        console.log("log?");
+        appInsightsClient?.trackEvent({
+          name: eventName,
+          properties: data?.properties,
+          measurements: data?.measurements,
+        });
+      } catch (e: any) {
+        throw new Error("Failed to log event to app insights!\n" + e.message);
+      }
+    },
+    logError: (exceptionName: Error, data?: SenderData) => {
+      try {
+        console.log("log?");
+        appInsightsClient?.trackException({
+          exception: exceptionName,
+          properties: data?.properties,
+          measurements: data?.measurements,
+        });
+      } catch (e: any) {
+        throw new Error("Failed to log event to app insights!\n" + e.message);
+      }
+    },
+    flush: async () => {
+      try {
+        appInsightsClient?.flush();
+      } catch (e: any) {
+        throw new Error("Failed to flush app insights!\n" + e.message);
+      }
+    },
+  };
+
+  return telemetryClient;
+};
+
+export default class TelemetryReporter extends BaseTelemetryReporter {
+  constructor(key: string | undefined) {
+    if (key) {
+      let clientFactory = (key: string) => appInsightsClientFactory(key);
+      const sender = new BaseTelemetrySender(key, clientFactory);
+      super(sender);
+    }
+  }
+}

--- a/src/core/telemetry/telemetryReporter.ts
+++ b/src/core/telemetry/telemetryReporter.ts
@@ -17,7 +17,6 @@ const appInsightsClientFactory = async (key: string): Promise<BaseTelemetryClien
       appInsightsClient = new appInsights.TelemetryClient(key);
       appInsightsClient.channel.setUseDiskRetryCaching(true);
     } else {
-      console.log("setup");
       appInsights
         .setup(key)
         .setAutoCollectRequests(false)
@@ -31,7 +30,6 @@ const appInsightsClientFactory = async (key: string): Promise<BaseTelemetryClien
         .start();
       appInsightsClient = appInsights.defaultClient;
     }
-    console.log("created");
   } catch (e: any) {
     return Promise.reject("Failed to initialize app insights!\n" + e.message);
   }
@@ -39,7 +37,6 @@ const appInsightsClientFactory = async (key: string): Promise<BaseTelemetryClien
   const telemetryClient: BaseTelemetryClient = {
     logEvent: (eventName: string, data?: SenderData) => {
       try {
-        console.log("log?");
         appInsightsClient?.trackEvent({
           name: eventName,
           properties: data?.properties,
@@ -49,16 +46,15 @@ const appInsightsClientFactory = async (key: string): Promise<BaseTelemetryClien
         throw new Error("Failed to log event to app insights!\n" + e.message);
       }
     },
-    logError: (exceptionName: Error, data?: SenderData) => {
+    logException: (exceptionName: Error, data?: SenderData) => {
       try {
-        console.log("log?");
         appInsightsClient?.trackException({
           exception: exceptionName,
           properties: data?.properties,
           measurements: data?.measurements,
         });
       } catch (e: any) {
-        throw new Error("Failed to log event to app insights!\n" + e.message);
+        throw new Error("Failed to log exception to app insights!\n" + e.message);
       }
     },
     flush: async () => {

--- a/src/core/telemetry/telemetryReporter.ts
+++ b/src/core/telemetry/telemetryReporter.ts
@@ -75,6 +75,8 @@ export default class TelemetryReporter extends BaseTelemetryReporter {
       let clientFactory = (key: string) => appInsightsClientFactory(key);
       const sender = new BaseTelemetrySender(key, clientFactory);
       super(sender);
+    } else {
+      throw new Error("Please provide aiKey of your AppInsights instance!\n");
     }
   }
 }

--- a/src/core/telemetry/telemetryReporterTypes.d.ts
+++ b/src/core/telemetry/telemetryReporterTypes.d.ts
@@ -1,0 +1,48 @@
+export interface TelemetryEventProperties {
+  readonly [key: string]: string;
+}
+
+export interface RawTelemetryEventProperties {
+  readonly [key: string]: any;
+}
+
+export interface TelemetryEventMeasurements {
+  readonly [key: string]: number;
+}
+
+export default class TelemetryReporter {
+  /**
+   * @param key The app insights key
+   */
+  constructor(key: string);
+
+  /**
+   * Sends a telemetry event with the given properties and measurements
+   * Properties are sanitized on best-effort basis to remove sensitive data prior to sending.
+   * @param eventName The name of the event
+   * @param properties The set of properties to add to the event in the form of a string key value pair
+   * @param measurements The set of measurements to add to the event in the form of a string key  number value pair
+   */
+  sendTelemetryEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void;
+  /**
+   * Sends a telemetry error event with the given properties, measurements.
+   * **Note**: The errorProps parameter has been removed since v0.6, if you would like to remove a property please use the replacementOptions parameter in the constructor.
+   * @param eventName The name of the event
+   * @param properties The set of properties to add to the event in the form of a string key value pair
+   * @param measurements The set of measurements to add to the event in the form of a string key  number value pair
+   */
+  sendTelemetryErrorEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void;
+
+  /**
+   * Sends an exception which includes the error stack, properties, and measurements
+   * @param error The error to send
+   * @param properties The set of properties to add to the event in the form of a string key value pair
+   * @param measurements The set of measurements to add to the event in the form of a string key  number value pair
+   */
+  sendTelemetryException(error: Error, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void;
+
+  /**
+   * Disposes of the telemetry reporter. This flushes the remaining events and disposes of the telemetry client.
+   */
+  dispose(): Promise<any>;
+}

--- a/src/core/telemetry/telemetryReporterTypes.d.ts
+++ b/src/core/telemetry/telemetryReporterTypes.d.ts
@@ -39,7 +39,7 @@ export default class TelemetryReporter {
    * @param properties The set of properties to add to the event in the form of a string key value pair
    * @param measurements The set of measurements to add to the event in the form of a string key  number value pair
    */
-  sendTelemetryException(error: Error, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void;
+  sendTelemetryException(exception: Error, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void;
 
   /**
    * Disposes of the telemetry reporter. This flushes the remaining events and disposes of the telemetry client.

--- a/src/core/telemetry/utils.ts
+++ b/src/core/telemetry/utils.ts
@@ -8,3 +8,8 @@ export function collectTelemetryEvent(event: string, properties?: TelemetryEvent
   const reporter: TelemetryReporter = new TelemetryReporter(process.env.APPLICATIONINSIGHTS_CONNECTION_STRING);
   reporter.sendTelemetryEvent(event, properties, measurements);
 }
+
+export function collectTelemetryException(exception: Error, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements) {
+  const reporter: TelemetryReporter = new TelemetryReporter(process.env.APPLICATIONINSIGHTS_CONNECTION_STRING);
+  reporter.sendTelemetryException(exception, properties, measurements);
+}

--- a/src/core/telemetry/utils.ts
+++ b/src/core/telemetry/utils.ts
@@ -1,0 +1,10 @@
+import dotenv from "dotenv";
+dotenv.config();
+
+import TelemetryReporter from "./telemetryReporter";
+import type { TelemetryEventMeasurements, TelemetryEventProperties } from "./telemetryReporterTypes";
+
+export function collectTelemetryEvent(event: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements) {
+  const reporter: TelemetryReporter = new TelemetryReporter(process.env.APPLICATIONINSIGHTS_CONNECTION_STRING);
+  reporter.sendTelemetryEvent(event, properties, measurements);
+}


### PR DESCRIPTION
Used AppInisghts for javascript SDK and added a basic telemetry reporter class which is used to send event and error data to an AppInisghts instance. When this reporter is called it lazy loads the appinsights client and sends data as a batch to appinisghts instance. Until the client is loaded event and exception data are stored in queues. Collection of required telemetry data from CLI code will be taken care of in next PR.