### PR TITLE
feat(telemetry): added new flags and env variable for opting out

### DIFF
--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -2,3 +2,4 @@ export * from "./login";
 export * from "./deploy";
 export * from "./init";
 export * from "./start";
+export * from "./telemetry";

--- a/src/cli/commands/telemetry/index.ts
+++ b/src/cli/commands/telemetry/index.ts
@@ -1,0 +1,2 @@
+export * from "./telemetry";
+export { default as registerTelemetry } from "./register";

--- a/src/cli/commands/telemetry/register.ts
+++ b/src/cli/commands/telemetry/register.ts
@@ -6,7 +6,7 @@ export default function registerCommand(program: Command) {
   program
     .command("telemetry")
     .usage("[options]")
-    .description("telemetry")
+    .description("enable/disable SWA CLI telemetry capturing")
     .option("-dt, --disable", "opt out of telemetry", undefined)
     .option("-et, --enable", "opt in telemetry", undefined)
     .option("-st, --status", "status of telemetry", undefined)

--- a/src/cli/commands/telemetry/register.ts
+++ b/src/cli/commands/telemetry/register.ts
@@ -1,0 +1,17 @@
+import { Command } from "commander";
+import { configureOptions } from "../../../core";
+import { telemetry } from "./telemetry";
+
+export default function registerCommand(program: Command) {
+  program
+    .command("telemetry")
+    .usage("[options]")
+    .description("telemetry")
+    .option("-dt, --disable", "opt out of telemetry", undefined)
+    .option("-et, --enable", "opt in telemetry", undefined)
+    .option("-st, --status", "status of telemetry", undefined)
+    .action(async (_options: SWACLIConfig, command: Command) => {
+      const options = await configureOptions(undefined, command.optsWithGlobals(), command, "telemetry");
+      await telemetry(options);
+    });
+}

--- a/src/cli/commands/telemetry/register.ts
+++ b/src/cli/commands/telemetry/register.ts
@@ -6,10 +6,10 @@ export default function registerCommand(program: Command) {
   program
     .command("telemetry")
     .usage("[options]")
-    .description("enable/disable SWA CLI telemetry capturing")
-    .option("-dt, --disable", "opt out of telemetry", undefined)
-    .option("-et, --enable", "opt in telemetry", undefined)
-    .option("-st, --status", "status of telemetry", undefined)
+    .description("manage SWA CLI telemetry capturing")
+    .option("-dt, --disable", "opt out of telemetry capturing", undefined)
+    .option("-et, --enable", "opt in telemetry capturing", undefined)
+    .option("-st, --status", "status of telemetry capturing", undefined)
     .action(async (_options: SWACLIConfig, command: Command) => {
       const options = await configureOptions(undefined, command.optsWithGlobals(), command, "telemetry");
       await telemetry(options);

--- a/src/cli/commands/telemetry/register.ts
+++ b/src/cli/commands/telemetry/register.ts
@@ -13,5 +13,20 @@ export default function registerCommand(program: Command) {
     .action(async (_options: SWACLIConfig, command: Command) => {
       const options = await configureOptions(undefined, command.optsWithGlobals(), command, "telemetry");
       await telemetry(options);
-    });
+    })
+    .addHelpText(
+      "after",
+      `
+Examples:
+
+opt out of telemetry capturing
+swa telemetry --disable
+
+opt in telemetry capturing
+swa telemetry --enable
+
+check the status of telemetry capturing
+saw telemetry --status
+      `
+    );
 }

--- a/src/cli/commands/telemetry/telemetry.spec.ts
+++ b/src/cli/commands/telemetry/telemetry.spec.ts
@@ -1,0 +1,94 @@
+import fs from "fs";
+import mockFs from "mock-fs";
+import os from "os";
+import path from "path";
+import { logger } from "../../../core";
+import { ENV_FILENAME } from "../../../core/constants";
+import { telemetry } from "./telemetry";
+
+jest.mock("../../../core/utils/logger", () => {
+  return {
+    logger: {
+      error: jest.fn(),
+      log: jest.fn(),
+      warn: jest.fn(),
+      silly: jest.fn(),
+    },
+    logGiHubIssueMessageAndExit: jest.fn(),
+  };
+});
+
+describe("swa telemetry", () => {
+  afterEach(() => {
+    mockFs.restore();
+  });
+
+  it("Telemetry should be enabled by default", async () => {
+    mockFs();
+    await telemetry({ status: true });
+    expect(logger.log).toHaveBeenNthCalledWith(1, "Telemetry capturing is enabled.");
+  });
+
+  it("should store disable telemetry setting in .env file", async () => {
+    await telemetry({ disable: true });
+    const envFile = path.join(os.homedir(), ".swa", ENV_FILENAME);
+    const envFileContent = fs.readFileSync(envFile, "utf-8");
+
+    expect(envFileContent).toMatchSnapshot(`
+        "SWA_DISABLE_TELEMETRY=true"
+        `);
+  });
+
+  it("should log the telemetry setting as disabled", async () => {
+    await telemetry({ status: true });
+    expect(logger.log).toHaveBeenNthCalledWith(3, "Telemetry capturing is disabled.");
+  });
+
+  it("should store enable telemetry setting in .env file", async () => {
+    await telemetry({ enable: true });
+    const envFile = path.join(os.homedir(), ".swa", ENV_FILENAME);
+    const envFileContent = fs.readFileSync(envFile, "utf-8");
+
+    expect(envFileContent).toMatchSnapshot(`
+        "SWA_DISABLE_TELEMETRY=false"
+        `);
+  });
+
+  it("should log the telemetry setting as enabled", async () => {
+    await telemetry({ status: true });
+    expect(logger.log).toHaveBeenNthCalledWith(5, "Telemetry capturing is enabled.");
+  });
+
+  it("should disable telemetry when both --enable and --disable flags are used", async () => {
+    await telemetry({ disable: true, enable: true });
+    const envFile = path.join(os.homedir(), ".swa", ENV_FILENAME);
+    const envFileContent = fs.readFileSync(envFile, "utf-8");
+
+    expect(envFileContent).toMatchSnapshot(`
+        "SWA_DISABLE_TELEMETRY=true"
+        `);
+  });
+
+  it("should log the telemetry setting as disabled", async () => {
+    await telemetry({ status: true });
+    expect(logger.log).toHaveBeenNthCalledWith(7, "Telemetry capturing is disabled.");
+  });
+
+  it("should warn when both --enable and --status flags are used", async () => {
+    mockFs();
+    await telemetry({ enable: true, status: true });
+    expect(logger.warn).toHaveBeenNthCalledWith(1, "The flags --disable and --enable can't be used alongside the flag --status!");
+  });
+
+  it("should warn when both --disable and --status flags are used", async () => {
+    mockFs();
+    await telemetry({ disable: true, status: true });
+    expect(logger.warn).toHaveBeenNthCalledWith(1, "The flags --disable and --enable can't be used alongside the flag --status!");
+  });
+
+  it("should warn when all 3 --disable, --enable and --status flags are used", async () => {
+    mockFs();
+    await telemetry({ enable: true, disable: true, status: true });
+    expect(logger.warn).toHaveBeenNthCalledWith(1, "The flags --disable and --enable can't be used alongside the flag --status!");
+  });
+});

--- a/src/cli/commands/telemetry/telemetry.spec.ts
+++ b/src/cli/commands/telemetry/telemetry.spec.ts
@@ -35,7 +35,7 @@ describe("swa telemetry", () => {
     const envFileContent = fs.readFileSync(envFile, "utf-8");
 
     expect(envFileContent).toMatchSnapshot(`
-        "SWA_DISABLE_TELEMETRY=true"
+        "SWA_CLI_CAPTURE_TELEMETRY=false"
         `);
   });
 
@@ -50,7 +50,7 @@ describe("swa telemetry", () => {
     const envFileContent = fs.readFileSync(envFile, "utf-8");
 
     expect(envFileContent).toMatchSnapshot(`
-        "SWA_DISABLE_TELEMETRY=false"
+        "SWA_CLI_CAPTURE_TELEMETRY=true"
         `);
   });
 
@@ -59,36 +59,23 @@ describe("swa telemetry", () => {
     expect(logger.log).toHaveBeenNthCalledWith(5, "Telemetry capturing is enabled.");
   });
 
-  it("should disable telemetry when both --enable and --disable flags are used", async () => {
+  it("should warn when both --enable and --disable flags are used", async () => {
     await telemetry({ disable: true, enable: true });
-    const envFile = path.join(os.homedir(), ".swa", ENV_FILENAME);
-    const envFileContent = fs.readFileSync(envFile, "utf-8");
-
-    expect(envFileContent).toMatchSnapshot(`
-        "SWA_DISABLE_TELEMETRY=true"
-        `);
-  });
-
-  it("should log the telemetry setting as disabled", async () => {
-    await telemetry({ status: true });
-    expect(logger.log).toHaveBeenNthCalledWith(7, "Telemetry capturing is disabled.");
+    expect(logger.warn).toHaveBeenNthCalledWith(1, "Using the flags --disable and --enable together is not supported!");
   });
 
   it("should warn when both --enable and --status flags are used", async () => {
-    mockFs();
     await telemetry({ enable: true, status: true });
-    expect(logger.warn).toHaveBeenNthCalledWith(1, "The flag --status can't be used alongside the flags --disable and --enable!");
+    expect(logger.warn).toHaveBeenNthCalledWith(2, "The flag --status can't be used alongside the flags --disable and --enable!");
   });
 
   it("should warn when both --disable and --status flags are used", async () => {
-    mockFs();
     await telemetry({ disable: true, status: true });
-    expect(logger.warn).toHaveBeenNthCalledWith(1, "The flag --status can't be used alongside the flags --disable and --enable!");
+    expect(logger.warn).toHaveBeenNthCalledWith(3, "The flag --status can't be used alongside the flags --disable and --enable!");
   });
 
   it("should warn when all 3 --disable, --enable and --status flags are used", async () => {
-    mockFs();
     await telemetry({ enable: true, disable: true, status: true });
-    expect(logger.warn).toHaveBeenNthCalledWith(1, "The flag --status can't be used alongside the flags --disable and --enable!");
+    expect(logger.warn).toHaveBeenNthCalledWith(4, "The flag --status can't be used alongside the flags --disable and --enable!");
   });
 });

--- a/src/cli/commands/telemetry/telemetry.spec.ts
+++ b/src/cli/commands/telemetry/telemetry.spec.ts
@@ -77,18 +77,18 @@ describe("swa telemetry", () => {
   it("should warn when both --enable and --status flags are used", async () => {
     mockFs();
     await telemetry({ enable: true, status: true });
-    expect(logger.warn).toHaveBeenNthCalledWith(1, "The flags --disable and --enable can't be used alongside the flag --status!");
+    expect(logger.warn).toHaveBeenNthCalledWith(1, "The flag --status can't be used alongside the flags --disable and --enable!");
   });
 
   it("should warn when both --disable and --status flags are used", async () => {
     mockFs();
     await telemetry({ disable: true, status: true });
-    expect(logger.warn).toHaveBeenNthCalledWith(1, "The flags --disable and --enable can't be used alongside the flag --status!");
+    expect(logger.warn).toHaveBeenNthCalledWith(1, "The flag --status can't be used alongside the flags --disable and --enable!");
   });
 
   it("should warn when all 3 --disable, --enable and --status flags are used", async () => {
     mockFs();
     await telemetry({ enable: true, disable: true, status: true });
-    expect(logger.warn).toHaveBeenNthCalledWith(1, "The flags --disable and --enable can't be used alongside the flag --status!");
+    expect(logger.warn).toHaveBeenNthCalledWith(1, "The flag --status can't be used alongside the flags --disable and --enable!");
   });
 });

--- a/src/cli/commands/telemetry/telemetry.ts
+++ b/src/cli/commands/telemetry/telemetry.ts
@@ -1,56 +1,54 @@
 import chalk from "chalk";
-import dotenv from "dotenv";
 import os from "os";
 import path from "path";
 import { logger } from "../../../core";
+import { readCLIEnvFile } from "../../../core";
 import { ENV_FILENAME } from "../../../core/constants";
-import { existsSync, promises as fsPromises } from "fs";
-const { readFile, writeFile } = fsPromises;
+import { promises as fsPromises } from "fs";
+const { writeFile } = fsPromises;
 
 export async function telemetry(options: SWACLIConfig) {
   const { disable, enable, status } = options;
-  const envFile = path.join(os.homedir(), ".swa", ENV_FILENAME);
-  const envFileExists = existsSync(envFile);
-  const envFileContent = envFileExists ? await readFile(envFile, "utf8") : "";
-  const buf = Buffer.from(envFileContent);
 
-  // in case the .env file format changes in the future, we can use the following to parse the file
-  const config = dotenv.parse(buf);
+  const config = await readCLIEnvFile();
   const oldEnvFileLines = Object.keys(config).map((key) => `${key}=${config[key]}`);
   const newEnvFileLines = [];
 
   if ((disable || enable) && !status) {
     //telemetry capturing is enabled by default
-    let disableTelemetryStatus = "false";
-    if (disable && enable == undefined) {
+    let disableTelemetryStatus = undefined;
+    if (disable) {
       disableTelemetryStatus = "true";
     } else if (disable == undefined && enable) {
       disableTelemetryStatus = "false";
-    } else {
-      logger.warn("The flags --disable and --enable can't be used at the same time!");
     }
 
     const entry = `SWA_DISABLE_TELEMETRY=${disableTelemetryStatus}`;
 
-    if (!envFileContent.includes("SWA_DISABLE_TELEMETRY")) {
-      newEnvFileLines.push(entry);
-    } else {
-      const index = oldEnvFileLines.indexOf(`SWA_DISABLE_TELEMETRY=${config["SWA_DISABLE_TELEMETRY"]}`);
-      oldEnvFileLines.splice(index, 1);
-      newEnvFileLines.push(entry);
+    if (disableTelemetryStatus) {
+      if (!config["SWA_DISABLE_TELEMETRY"]) {
+        newEnvFileLines.push(entry);
+      } else {
+        const index = oldEnvFileLines.indexOf(`SWA_DISABLE_TELEMETRY=${config["SWA_DISABLE_TELEMETRY"]}`);
+        oldEnvFileLines.splice(index, 1);
+        newEnvFileLines.push(entry);
+      }
     }
 
     // write file if we have at least one new env line
     if (newEnvFileLines.length > 0) {
       const envFileContentWithProjectDetails = [...oldEnvFileLines, ...newEnvFileLines].join("\n");
+      const envFile = path.join(os.homedir(), ".swa", ENV_FILENAME);
       await writeFile(envFile, envFileContentWithProjectDetails);
       logger.log(chalk.green(`✔ Saved Telemetry setting in ${ENV_FILENAME} file at ${path.join(os.homedir(), ".swa")}`));
     }
   } else if (!disable && !enable && status) {
-    if (config["SWA_DISABLE_TELEMETRY"] == "true") {
+    if (config["SWA_DISABLE_TELEMETRY"] && config["SWA_DISABLE_TELEMETRY"].toLowerCase() === "true") {
       logger.log("Telemetry capturing is disabled.");
-    } else {
+    } else if (!config["SWA_DISABLE_TELEMETRY"] || config["SWA_DISABLE_TELEMETRY"].toLowerCase() === "false") {
       logger.log("Telemetry capturing is enabled.");
     }
+  } else {
+    logger.warn("The flags --disable and --enable can't be used alongside the flag --status!");
   }
 }

--- a/src/cli/commands/telemetry/telemetry.ts
+++ b/src/cli/commands/telemetry/telemetry.ts
@@ -49,6 +49,6 @@ export async function telemetry(options: SWACLIConfig) {
       logger.log("Telemetry capturing is enabled.");
     }
   } else {
-    logger.warn("The flags --disable and --enable can't be used alongside the flag --status!");
+    logger.warn("The flag --status can't be used alongside the flags --disable and --enable!");
   }
 }

--- a/src/cli/commands/telemetry/telemetry.ts
+++ b/src/cli/commands/telemetry/telemetry.ts
@@ -49,9 +49,9 @@ export async function telemetry(options: SWACLIConfig) {
     }
   } else if (!disable && !enable && status) {
     if (process.env.SWA_DISABLE_TELEMETRY == "true") {
-      logger.log("You are currently opted out of sending telemetry!");
+      logger.log("Telemetry capturing is disabled.");
     } else {
-      logger.log("You opted to send the telemetry!");
+      logger.log("Telemetry capturing is enabled.");
     }
   }
 }

--- a/src/cli/commands/telemetry/telemetry.ts
+++ b/src/cli/commands/telemetry/telemetry.ts
@@ -1,0 +1,57 @@
+import { logger } from "../../../core";
+import path from "path";
+import dotenv from "dotenv";
+import { ENV_FILENAME } from "../../../core/constants";
+import { updateGitIgnore } from "../../../core/git";
+import { existsSync, promises as fsPromises } from "fs";
+const { readFile, writeFile } = fsPromises;
+
+export async function telemetry(options: SWACLIConfig) {
+  let { disable, enable, status } = options;
+  const envFile = path.join(process.cwd(), ENV_FILENAME);
+  const envFileExists = existsSync(envFile);
+  const envFileContent = envFileExists ? await readFile(envFile, "utf8") : "";
+  const buf = Buffer.from(envFileContent);
+
+  // in case the .env file format changes in the future, we can use the following to parse the file
+  const config = dotenv.parse(buf);
+  const oldEnvFileLines = Object.keys(config).map((key) => `${key}=${config[key]}`);
+  const newEnvFileLines = [];
+
+  if ((disable || enable) && !status) {
+    let disableTelemetryStatus = undefined;
+    if (disable && enable == undefined) {
+      disableTelemetryStatus = "true";
+    } else if (disable == undefined && enable) {
+      disableTelemetryStatus = "false";
+    } else {
+      logger.warn("The flags --disable and --enable can't be used at the same time!");
+    }
+
+    let entry = `SWA_DISABLE_TELEMETRY=${disableTelemetryStatus}`;
+
+    if (disableTelemetryStatus) {
+      if (!envFileContent.includes("SWA_DISABLE_TELEMETRY")) {
+        newEnvFileLines.push(entry);
+      } else {
+        const index = oldEnvFileLines.indexOf(`SWA_DISABLE_TELEMETRY=${process.env.SWA_DISABLE_TELEMETRY}`);
+        oldEnvFileLines.splice(index, 1);
+        newEnvFileLines.push(entry);
+      }
+    }
+
+    // write file if we have at least one new env line
+    if (newEnvFileLines.length > 0) {
+      const envFileContentWithProjectDetails = [...oldEnvFileLines, ...newEnvFileLines].join("\n");
+      await writeFile(envFile, envFileContentWithProjectDetails);
+
+      await updateGitIgnore(ENV_FILENAME);
+    }
+  } else if (!disable && !enable && status) {
+    if (process.env.SWA_DISABLE_TELEMETRY == "true") {
+      logger.log("You are currently opted out of sending telemetry!");
+    } else {
+      logger.log("You opted to send the telemetry!");
+    }
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@ import { registerStart } from "./commands/start";
 import { registerBuild } from "./commands/build";
 import { registerDocs } from "./commands/docs";
 import { promptOrUseDefault } from "../core/prompts";
+import { registerTelemetry } from "./commands";
 
 export * from "./commands";
 
@@ -97,6 +98,7 @@ export async function run(argv?: string[]) {
   registerInit(program);
   registerBuild(program);
   registerDocs(program);
+  registerTelemetry(program);
 
   program.showHelpAfterError();
   program.addOption(new Option("--ping").hideHelp());

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -3,7 +3,7 @@ import { DEFAULT_CONFIG } from "../config";
 import { address, isHttpUrl } from "./utils/net";
 
 export const STATIC_SITE_CLIENT_RELEASE_METADATA_URL = "https://swalocaldeploy.azureedge.net/downloads/versions.json";
-export const SWA_COMMANDS = ["login", "init", "start", "deploy", "build"] as const;
+export const SWA_COMMANDS = ["login", "init", "start", "deploy", "build", "telemetry"] as const;
 // Type cannot be in swa.d.ts as it's inferred from SWA_COMMANDS
 export type SWACommand = typeof SWA_COMMANDS[number];
 

--- a/src/core/telemetry/utils.ts
+++ b/src/core/telemetry/utils.ts
@@ -5,11 +5,15 @@ import TelemetryReporter from "./telemetryReporter";
 import type { TelemetryEventMeasurements, TelemetryEventProperties } from "./telemetryReporterTypes";
 
 export function collectTelemetryEvent(event: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements) {
-  const reporter: TelemetryReporter = new TelemetryReporter(process.env.APPLICATIONINSIGHTS_CONNECTION_STRING);
-  reporter.sendTelemetryEvent(event, properties, measurements);
+  if (process.env.SWA_DISABLE_TELEMETRY == "false") {
+    const reporter: TelemetryReporter = new TelemetryReporter(aiKey);
+    reporter.sendTelemetryEvent(event, properties, measurements);
+  }
 }
 
 export function collectTelemetryException(exception: Error, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements) {
-  const reporter: TelemetryReporter = new TelemetryReporter(process.env.APPLICATIONINSIGHTS_CONNECTION_STRING);
-  reporter.sendTelemetryException(exception, properties, measurements);
+  if (process.env.SWA_DISABLE_TELEMETRY == "false") {
+    const reporter: TelemetryReporter = new TelemetryReporter(aiKey);
+    reporter.sendTelemetryException(exception, properties, measurements);
+  }
 }

--- a/src/core/telemetry/utils.ts
+++ b/src/core/telemetry/utils.ts
@@ -6,18 +6,26 @@ import type { TelemetryEventMeasurements, TelemetryEventProperties } from "./tel
 import { readCLIEnvFile } from "../utils";
 
 const aiKey = "8428a7f6-6650-4490-a15a-c7f7a16449d7";
+
 export async function collectTelemetryEvent(event: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements) {
-  const config = await readCLIEnvFile();
-  if (config["SWA_DISABLE_TELEMETRY"].toLowerCase() === "false") {
-    const reporter: TelemetryReporter = new TelemetryReporter(aiKey);
+  const reporter = await GetTelemetryReporter();
+  if (reporter) {
     reporter.sendTelemetryEvent(event, properties, measurements);
   }
 }
 
 export async function collectTelemetryException(exception: Error, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements) {
-  const config = await readCLIEnvFile();
-  if (config["SWA_DISABLE_TELEMETRY"].toLowerCase() === "false") {
-    const reporter: TelemetryReporter = new TelemetryReporter(aiKey);
+  const reporter = await GetTelemetryReporter();
+  if (reporter) {
     reporter.sendTelemetryException(exception, properties, measurements);
   }
+}
+
+export async function GetTelemetryReporter() {
+  const config = await readCLIEnvFile();
+  if (config["SWA_CLI_CAPTURE_TELEMETRY"].toLowerCase() === "true") {
+    const reporter: TelemetryReporter = new TelemetryReporter(aiKey);
+    return reporter;
+  }
+  return undefined;
 }

--- a/src/core/telemetry/utils.ts
+++ b/src/core/telemetry/utils.ts
@@ -3,16 +3,20 @@ dotenv.config();
 
 import TelemetryReporter from "./telemetryReporter";
 import type { TelemetryEventMeasurements, TelemetryEventProperties } from "./telemetryReporterTypes";
+import { readCLIEnvFile } from "../utils";
 
-export function collectTelemetryEvent(event: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements) {
-  if (process.env.SWA_DISABLE_TELEMETRY == "false") {
+const aiKey = "8428a7f6-6650-4490-a15a-c7f7a16449d7";
+export async function collectTelemetryEvent(event: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements) {
+  const config = await readCLIEnvFile();
+  if (config["SWA_DISABLE_TELEMETRY"].toLowerCase() === "false") {
     const reporter: TelemetryReporter = new TelemetryReporter(aiKey);
     reporter.sendTelemetryEvent(event, properties, measurements);
   }
 }
 
-export function collectTelemetryException(exception: Error, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements) {
-  if (process.env.SWA_DISABLE_TELEMETRY == "false") {
+export async function collectTelemetryException(exception: Error, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements) {
+  const config = await readCLIEnvFile();
+  if (config["SWA_DISABLE_TELEMETRY"].toLowerCase() === "false") {
     const reporter: TelemetryReporter = new TelemetryReporter(aiKey);
     reporter.sendTelemetryException(exception, properties, measurements);
   }

--- a/src/core/utils/file.ts
+++ b/src/core/utils/file.ts
@@ -1,7 +1,11 @@
-import { promises as fs } from "fs";
+import dotenv from "dotenv";
+import { existsSync, promises as fs } from "fs";
+import os from "os";
 import path from "path";
 import { logger } from "./logger";
+import { ENV_FILENAME } from "./../constants";
 import { stripJsonComments } from "./strings";
+const { readFile } = fs;
 
 export async function safeReadJson(path: string): Promise<JsonData | undefined> {
   try {
@@ -59,4 +63,15 @@ export async function findUpPackageJsonDir(rootPath: string, startPath: string):
 
   const components = startPath.split(/[/\\]/).filter((c) => c);
   return find(components);
+}
+
+export async function readCLIEnvFile() {
+  const envFile = path.join(os.homedir(), ".swa", ENV_FILENAME);
+  const envFileExists = existsSync(envFile);
+  const envFileContent = envFileExists ? await readFile(envFile, "utf8") : "";
+
+  // in case the .env file format changes in the future, we can use the following to parse the file
+  const buf = Buffer.from(envFileContent);
+  const config = dotenv.parse(buf);
+  return config;
 }

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -71,6 +71,9 @@ declare interface SWACLIEnv extends StaticSiteClientEnv {
   AZURE_TENANT_ID?: string;
   AZURE_CLIENT_ID?: string;
   AZURE_CLIENT_SECRET?: string;
+
+  // swa telemetry
+  SWA_DISABLE_TELEMETRY?: string;
 }
 
 declare interface Context {
@@ -183,6 +186,11 @@ declare type SWACLISharedLoginOptions = LoginDetails & {
 
 declare type SWACLILoginOptions = SWACLISharedLoginOptions;
 
+declare type SWACLITelemetryOptions = {
+  disable?: boolean;
+  enable?: boolean;
+  status?: boolean;
+};
 // -- CLI Config options -----------------------------------------------------
 
 declare type SWACLIConfig = SWACLIGlobalOptions &
@@ -191,12 +199,14 @@ declare type SWACLIConfig = SWACLIGlobalOptions &
   SWACLIBuildOptions &
   SWACLIStartOptions &
   SWACLIDeployOptions &
-  SWACLIBuildOptions & {
+  SWACLIBuildOptions &
+  SWACLITelemetryOptions & {
     login?: SWACLIGlobalOptions & SWACLILoginOptions;
     init?: SWACLIGlobalOptions & SWACLIInitOptions;
     start?: SWACLIGlobalOptions & SWACLIStartOptions;
     deploy?: SWACLIGlobalOptions & SWACLIDeployOptions;
     build?: SWACLIGlobalOptions & SWACLIBuildOptions;
+    telemetry?: SWACLIGlobalOptions & SWACLITelemetryOptions;
   };
 
 // Information about the loaded config


### PR DESCRIPTION
Added commands to disable/enable telemetry capturing. Command would look like `swa telemetry --disable/enable`.
Also added an environment variable `SWA_DISABLE_TELEMETRY` where users can set the value to true/false.
Users can check the status of telemetry capturing using the command `swa telemetry --status`.
Only one of these flags can be used at a time.