### PR TITLE
fix: waitOn and fetch IPv4&v6 instead of localhost

### DIFF
--- a/.github/workflows/azuresdkdrop.yml
+++ b/.github/workflows/azuresdkdrop.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/src/core/utils/net.ts
+++ b/src/core/utils/net.ts
@@ -103,22 +103,33 @@ export async function validateDevServerConfig(url: string | undefined, timeout: 
     const resolvedPortNumber = await isAcceptingTcpConnections({ port, host: hostname });
     if (resolvedPortNumber !== 0) {
       const spinner = ora();
-      try {
-        spinner.start(`Waiting for ${chalk.green(url)} to be ready`);
-        await waitOn({
-          resources: [`tcp:${hostname}:${port}`],
-          delay: 1000, // initial delay in ms, default 0
-          interval: 100, // poll interval in ms, default 250ms
-          simultaneous: 1, // limit to 1 connection per resource at a time
-          timeout: timeout ? timeout * 1000 : timeout, // timeout in ms, default Infinity
-          tcpTimeout: 1000, // tcp timeout in ms, default 300ms
-          window: 1000, // stabilization time in ms, default 750ms
-          strictSSL: false,
-          verbose: false, // force disable verbose logs even if SWA_CLI_DEBUG is enabled
-        });
-        spinner.succeed(`Connected to ${chalk.green(url)} successfully`);
+      const waitOnOneOfResources = hostname === "localhost" ? [`tcp:127.0.0.1:${port}`, `tcp:[::1]:${port}`] : [`tcp:${hostname}:${port}`];
+      let isConnected = false;
+      spinner.start(`Waiting for ${chalk.green(url)} to be ready`);
+      for (let resource of waitOnOneOfResources) {
+        try {
+          await waitOn({
+            resources: [resource],
+            delay: 1000, // initial delay in ms, default 0
+            interval: 100, // poll interval in ms, default 250ms
+            simultaneous: 1, // limit to 1 connection per resource at a time
+            timeout: timeout ? timeout * 1000 : timeout, // timeout in ms, default Infinity
+            tcpTimeout: 1000, // tcp timeout in ms, default 300ms
+            window: 1000, // stabilization time in ms, default 750ms
+            strictSSL: false,
+            verbose: true, // force disable verbose logs even if SWA_CLI_DEBUG is enabled
+          });
+          isConnected = true;
+          logger.silly(`Connect to ${resource} successfully`);
+          break;
+        } catch (err) {
+          logger.silly(`Could not connect to ${resource}`);
+        }
+      }
+      if (isConnected) {
+        spinner.succeed(`Connected to ${url} successfully`);
         spinner.clear();
-      } catch (err) {
+      } else {
         spinner.fail();
         logger.error(`Could not connect to "${url}". Is the server up and running?`, true);
       }

--- a/src/msha/handlers/function.handler.ts
+++ b/src/msha/handlers/function.handler.ts
@@ -76,8 +76,8 @@ async function resolveLocalhostByFetching(url: string) {
   });
 
   try {
-    const avaliableUrl = await Promise.any(promises);
-    return avaliableUrl;
+    const availableUrl = await Promise.any(promises);
+    return availableUrl;
   } catch {
     throw new Error('Error: "localhost" can not be resolved to either IPv4 or IPv6. Please check your network settings.');
   }


### PR DESCRIPTION
Fix: issue [#663](https://github.com/Azure/static-web-apps-cli/issues/663).
Use 127.0.0.1 and [::1] for waitOn() and fetch() when using "swa start src --api-location api" with the default --host=localhost. Then check if any of them successes. This is because localhost may not be resolved to ipv4 on some systems.