### PR TITLE
fix: accept apiDevserverUrl with non-ok response

### DIFF
--- a/src/msha/handlers/function.handler.ts
+++ b/src/msha/handlers/function.handler.ts
@@ -63,11 +63,10 @@ async function resolveLocalhostByFetching(url: string) {
       .then((response) => {
         if (response.ok || response.redirected) {
           logger.silly(`Fetch ${Url} successfully`);
-          return Url;
         } else {
-          logger.silly(`Fetch ${Url} failed with status ${response.status} ${response.statusText}`);
-          throw new Error(`Fetch ${Url} failed with status ${response.status} ${response.statusText}`);
+          logger.warn(`Fetch ${Url} with status ${response.status} ${response.statusText}`);
         }
+        return Url;
       })
       .catch((err) => {
         logger.silly(`Could not fetch ${Url}`);


### PR DESCRIPTION
This PR fixs [ISSUE #733](https://github.com/Azure/static-web-apps-cli/issues/733). If an api dev server are used, and the apiDevserverUrl can be fetched, swa-cli will accept it even if the response is not ok, for example 404 not found.