### PR TITLE
Jikun/start or deploy from outside

### DIFF
--- a/src/msha/handlers/function.handler.ts
+++ b/src/msha/handlers/function.handler.ts
@@ -63,11 +63,10 @@ async function resolveLocalhostByFetching(url: string) {
       .then((response) => {
         if (response.ok || response.redirected) {
           logger.silly(`Fetch ${Url} successfully`);
-          return Url;
         } else {
-          logger.silly(`Fetch ${Url} failed with status ${response.status} ${response.statusText}`);
-          throw new Error(`Fetch ${Url} failed with status ${response.status} ${response.statusText}`);
+          logger.warn(`Fetch ${Url} with status ${response.status} ${response.statusText}`);
         }
+        return Url;
       })
       .catch((err) => {
         logger.silly(`Could not fetch ${Url}`);


### PR DESCRIPTION
Supported "swa start app1" or "swa deploy app1" outside the app1 folder.
For example, under the current working dir containing two projects "app1" and "app2", the above commands will work if there is a "swa-cli.config.json" in "app1" folder, while in the past users must run "swa start" under the app folder.