### PR TITLE
fix(cli): fix typo in start command

### DIFF
--- a/src/cli/commands/start/start.ts
+++ b/src/cli/commands/start/start.ts
@@ -352,7 +352,7 @@ export async function start(options: SWACLIConfig) {
             commandMessage = `the --run command exited with code ${exitCode}`;
             break;
         }
-        logger.error(`SWA emulator stoped because ${commandMessage}.`, true);
+        logger.error(`SWA emulator stopped because ${commandMessage}.`, true);
       }
     )
     .catch((err) => {


### PR DESCRIPTION
Changed "stoped" to "stopped" in a log error

Credit @camper0008 for spotting this.

["Stop" and "Stopped", Merriam Webster Dictionary](https://www.merriam-webster.com/dictionary/stop)