### PR TITLE
Revert "chore: prep-release 1.1.5"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure/static-web-apps-cli",
-  "version": "1.1.5",
+  "version": "1.1.5-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure/static-web-apps-cli",
-      "version": "1.1.5",
+      "version": "1.1.5-alpha",
       "license": "MIT",
       "dependencies": {
         "@azure/arm-appservice": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/static-web-apps-cli",
-  "version": "1.1.5",
+  "version": "1.1.5-alpha",
   "description": "Azure Static Web Apps CLI",
   "scripts": {
     "test": "jest --detectOpenHandles --silent --verbose",


### PR DESCRIPTION
Reverts Azure/static-web-apps-cli#747 due to GitHub Codespaces Prebuilds. npm Has been updated to 10.1.0, which hasn't supported node 16 any more.