### PR TITLE
Light / Dark theme applied by default based on OS / Browser preference

### DIFF
--- a/docs/www/docusaurus.config.js
+++ b/docs/www/docusaurus.config.js
@@ -94,6 +94,11 @@ const config = {
         style: "dark",
         copyright: `Copyright © ${new Date().getFullYear()} Microsoft | Built with Docusaurus and Iconcloud.design <br>build: ${getBuildId()}`,
       },
+      colorMode: {
+        defaultMode: 'light',
+        disableSwitch: false,
+        respectPrefersColorScheme: true,
+      },
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,


### PR DESCRIPTION
Right now, Light theme is applied even users OS / Browser preference is dark.

Pullrequest is to apply Light / Dark theme by default based on OS / Browser preference

docusaurus documentation:
https://docusaurus.io/docs/api/themes/configuration#color-mode---dark-mode

[Screencast from 03-10-23 07_12_07 PM IST.webm](https://github.com/Azure/static-web-apps-cli/assets/9389944/7d3fce99-d182-4c36-8b19-6ce7d4e94e5f)
