### PR TITLE
fix: revert changes that cause slow proxying

### DIFF
--- a/src/core/utils/net.ts
+++ b/src/core/utils/net.ts
@@ -103,7 +103,7 @@ export async function validateDevServerConfig(url: string | undefined, timeout: 
     const resolvedPortNumber = await isAcceptingTcpConnections({ port, host: hostname });
     if (resolvedPortNumber !== 0) {
       const spinner = ora();
-      let waitOnOneOfResources = hostname === "localhost" ? [`tcp:127.0.0.1:${port}`, `tcp:localhost:${port}`] : [`tcp:${hostname}:${port}`];
+      const waitOnOneOfResources = hostname === "localhost" ? [`tcp:127.0.0.1:${port}`, `tcp:[::1]:${port}`] : [`tcp:${hostname}:${port}`];
       spinner.start(`Waiting for ${chalk.green(url)} to be ready`);
 
       let promises = waitOnOneOfResources.map((resource) => {
@@ -130,7 +130,7 @@ export async function validateDevServerConfig(url: string | undefined, timeout: 
 
       try {
         await Promise.any(promises);
-        spinner.succeed(`${url} validated successfully`);
+        spinner.succeed(`Connected to ${url} successfully`);
         spinner.clear();
       } catch {
         spinner.fail();


### PR DESCRIPTION
This PR addresses https://github.com/Azure/static-web-apps-cli/issues/736 which concerns slow proxied requests for static content.

These slow proxied requests were caused by the changes made by @cjk7989 in https://github.com/Azure/static-web-apps-cli/pull/720

Whilst well intended, they made the SWA CLI very difficult to use for local development as of 1.1.4 when the changes were released.

Looking at the comments in https://github.com/Azure/static-web-apps-cli/issues/736 it's clear this is affecting many people.  This PR reverts that change.

Speaking for my own organisation, we have widely pinned to 1.1.3.

## Motivations

1. The implemented change has not resulted an improved development experience
2. The origin motivation behind the changes in https://github.com/Azure/static-web-apps-cli/pull/720 was to resolve https://github.com/Azure/static-web-apps-cli/issues/663.  Those issues arose with early versions of Node.js 18 that were affecting `wait-on`.  That issue is now resolved with Node.js according this this: https://github.com/jeffbski/wait-on/issues/137#issuecomment-1775289798 - Node.js 20 is now the LTS version of Node.js.

