### PR TITLE
ci: change node-version from '>=18.x' to 18.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        node-version: [14.x, 15.x, 16.x, 17.x, '>= 18.x']
+        node-version: [14.x, 15.x, 16.x, 17.x, 18.x]
 
     name: "test: use node ${{ matrix.node-version }}"
     steps:
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        node-version: [14.x, 15.x, 16.x, 17.x, '>= 18.x']
+        node-version: [14.x, 15.x, 16.x, 17.x, 18.x]
 
     name: "deploy: use node ${{ matrix.node-version }}"
     steps:
@@ -92,7 +92,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        node-version: [14.x, 15.x, 16.x, 17.x, '>= 18.x']
+        node-version: [14.x, 15.x, 16.x, 17.x, 18.x]
 
     name: "test: use node ${{ matrix.node-version }}"
     steps:
@@ -123,7 +123,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        node-version: [14.x, 15.x, 16.x, 17.x, '>= 18.x']
+        node-version: [14.x, 15.x, 16.x, 17.x, 18.x]
 
     name: "deploy: use node ${{ matrix.node-version }}"
     steps:
@@ -156,7 +156,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        node-version: [14.x, 15.x, 16.x, 17.x, '>= 18.x']
+        node-version: [14.x, 15.x, 16.x, 17.x, 18.x]
 
     name: "test: use node ${{ matrix.node-version }}"
     steps:
@@ -187,7 +187,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        node-version: [14.x, 15.x, 16.x, 17.x, '>= 18.x']
+        node-version: [14.x, 15.x, 16.x, 17.x, 18.x]
 
     name: "deploy: use node ${{ matrix.node-version }}"
     steps:


### PR DESCRIPTION
CI fails in unit tests in the job "test: use node >= 18.x". This is because the step "actions/setup-node@v1" will install node 20 with npm 10, which is unsupported by swa-cli. This PR modified '>=18.x' in the node-version of matirx to 18.x.