### PR TITLE
fix: remove initial delay to speed up requests

### DIFF
--- a/src/msha/middlewares/request.middleware.ts
+++ b/src/msha/middlewares/request.middleware.ts
@@ -109,7 +109,6 @@ async function serveStaticOrProxyResponse(req: http.IncomingMessage, res: http.S
       let promises = waitOnOneOfResources.map((resource) => {
         return waitOn({
           resources: [resource],
-          delay: 1000, // initial delay in ms, default 0
           interval: 100, // poll interval in ms, default 250ms
           simultaneous: 1, // limit to 1 connection per resource at a time
           timeout: 60000, // timeout in ms, default Infinity


### PR DESCRIPTION
The previous wait-on function has a param: initial delay = 1000, which caused the waiting time of a request to a dev server to at least 1000ms. This PR remove the param, which will be 0 by default.