### PR TITLE
fix: throw error when fail to load SWAConfigSchema

### DIFF
--- a/src/core/utils/user-config.ts
+++ b/src/core/utils/user-config.ts
@@ -105,7 +105,7 @@ export async function validateRuntimeConfigAndGetData(filepath: string): Promise
   logger.silly(`Loading staticwebapp.config.json schema...`);
   const schema = await loadSWAConfigSchema();
   if (!schema) {
-    logger.warn(`WARNING: Failed to load staticwebapp.config.json schema. Continuing without validation!`);
+    logger.error(`Failed to load staticwebapp.config.json schema. Continuing without validation!`, true);
     return null;
   }
 


### PR DESCRIPTION
Throw error for [ISSUE #754](https://github.com/Azure/static-web-apps-cli/issues/754) Will add the fallback schema file in the future.