### PR TITLE
feat: add client working dir to support deploying next.js

### DIFF
--- a/src/cli/commands/deploy/deploy.ts
+++ b/src/cli/commands/deploy/deploy.ts
@@ -63,13 +63,17 @@ export async function deploy(options: SWACLIConfig) {
     }
   }
 
-  // make sure outputLocation is set
-  const resolvedOutputLocation = path.resolve(appLocation, outputLocation || process.cwd());
+  logger.silly(`Resolving outputLocation=${outputLocation} full path...`);
+  let resolvedOutputLocation = path.resolve(appLocation, outputLocation as string);
 
   // if folder exists, deploy from a specific build folder (outputLocation), relative to appLocation
   if (!fs.existsSync(resolvedOutputLocation)) {
-    logger.error(`The folder "${resolvedOutputLocation}" is not found. Exit.`, true);
-    return;
+    if (!fs.existsSync(outputLocation as string)) {
+      logger.error(`The folder "${resolvedOutputLocation}" is not found. Exit.`, true);
+      return;
+    }
+    // otherwise, build folder (outputLocation) is using the absolute location
+    resolvedOutputLocation = path.resolve(outputLocation as string);
   }
 
   logger.log(`Deploying front-end files from folder:`);

--- a/src/cli/commands/deploy/deploy.ts
+++ b/src/cli/commands/deploy/deploy.ts
@@ -13,7 +13,7 @@ import {
   updateSwaCliConfigFile,
 } from "../../../core";
 import { chooseOrCreateProjectDetails, getStaticSiteDeployment } from "../../../core/account";
-import { DEFAULT_RUNTIME_LANGUAGE, STATIC_SITE_CLIENT_Working_Folder } from "../../../core/constants";
+import { DEFAULT_RUNTIME_LANGUAGE, STATIC_SITE_CLIENT_WORKING_FOLDER } from "../../../core/constants";
 import { cleanUp, getDeployClientPath } from "../../../core/deploy-client";
 import { swaCLIEnv } from "../../../core/env";
 import { getDefaultVersion } from "../../../core/functions-versions";
@@ -255,7 +255,7 @@ export async function deploy(options: SWACLIConfig) {
     FUNCTION_LANGUAGE_VERSION: apiVersion,
   };
 
-  const clientWorkingDir = path.resolve(deployClientEnv.REPOSITORY_BASE ?? "", STATIC_SITE_CLIENT_Working_Folder);
+  const clientWorkingDir = path.resolve(deployClientEnv.REPOSITORY_BASE ?? "", STATIC_SITE_CLIENT_WORKING_FOLDER);
   if (!fs.existsSync(clientWorkingDir)) {
     fs.mkdirSync(clientWorkingDir);
   }

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -8,6 +8,7 @@ export const DEPLOY_BINARY_NAME = "StaticSitesClient";
 export const DEPLOY_BINARY_STABLE_TAG = "stable";
 export const DEPLOY_FOLDER = path.join(os.homedir(), ".swa", "deploy");
 export const STATIC_SITE_CLIENT_RELEASE_METADATA_URL = "https://swalocaldeploy.azureedge.net/downloads/versions.json";
+export const STATIC_SITE_CLIENT_Working_Folder = "staticsites-cli";
 
 // Data-api-builder related constants
 export const DATA_API_BUILDER_BINARY_NAME = "DataApiBuilder";

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -8,7 +8,7 @@ export const DEPLOY_BINARY_NAME = "StaticSitesClient";
 export const DEPLOY_BINARY_STABLE_TAG = "stable";
 export const DEPLOY_FOLDER = path.join(os.homedir(), ".swa", "deploy");
 export const STATIC_SITE_CLIENT_RELEASE_METADATA_URL = "https://swalocaldeploy.azureedge.net/downloads/versions.json";
-export const STATIC_SITE_CLIENT_Working_Folder = "staticsites-cli";
+export const STATIC_SITE_CLIENT_WORKING_FOLDER = "staticsites-cli";
 
 // Data-api-builder related constants
 export const DATA_API_BUILDER_BINARY_NAME = "DataApiBuilder";

--- a/src/core/deploy-client.ts
+++ b/src/core/deploy-client.ts
@@ -109,9 +109,9 @@ export async function fetchClientVersionDefinition(releaseVersion: string): Prom
 
 // TODO: get StaticSiteClient to remove zip files
 // TODO: can these ZIPs be created under /tmp?
-export function cleanUp() {
+export function cleanUp(clientWorkingDir: string) {
   const clean = (file: string) => {
-    const filepath = path.join(process.cwd(), file);
+    const filepath = path.join(clientWorkingDir, file);
     if (fs.existsSync(filepath)) {
       try {
         fs.unlinkSync(filepath);
@@ -121,4 +121,10 @@ export function cleanUp() {
 
   clean(".\\app.zip");
   clean(".\\api.zip");
+
+  if (fs.existsSync(clientWorkingDir)) {
+    try {
+      fs.rmdirSync(clientWorkingDir, { recursive: true });
+    } catch {}
+  }
 }

--- a/src/core/utils/user-config.ts
+++ b/src/core/utils/user-config.ts
@@ -172,7 +172,10 @@ async function loadSWAConfigSchema(): Promise<JSONSchemaType<SWACLIConfigFile> |
       logger.silly(`Schema loaded successfully from ${schemaUrl}`);
       return (await res.json()) as JSONSchemaType<SWACLIConfigFile>;
     }
-  } catch {}
+    logger.silly(`Status: ${res.status} ${res.statusText}.`);
+  } catch (err) {
+    logger.warn((err as any).message);
+  }
 
   logger.silly(`Failed to load schema from ${schemaUrl}`);
   return null;


### PR DESCRIPTION
Refact the [PR #746](https://github.com/Azure/static-web-apps-cli/pull/746). This PR assigned a working dir "staticsites-cli" to run StaticSiteClient.exe when using "swa deploy". The dir will be created and removed automatically under the path of repo. In the deployment process, app and api folders will be copied to this working dir before zipping and uploading. This will fix the bug of https://github.com/Azure/static-web-apps-cli/issues/531, https://github.com/Azure/static-web-apps-cli/issues/550, and support next.js deployment.