### PR TITLE
feat: Support Azure CLI credential

### DIFF
--- a/src/core/account.ts
+++ b/src/core/account.ts
@@ -64,7 +64,7 @@ export async function authenticateWithAzureIdentity(details: LoginDetails = {}, 
   const environmentCredential = new EnvironmentCredential();
 
   const azureCliCredential = new AzureCliCredential({
-    tenantId: details.clientId,
+    tenantId: details.tenantId,
   });
 
   // Only use interactive browser credential if we're not running in docker

--- a/src/core/account.ts
+++ b/src/core/account.ts
@@ -2,6 +2,7 @@ import { StaticSiteARMResource, WebSiteManagementClient } from "@azure/arm-appse
 import { GenericResourceExpanded, ResourceGroup, ResourceManagementClient } from "@azure/arm-resources";
 import { Subscription, SubscriptionClient } from "@azure/arm-subscriptions";
 import {
+  AzureCliCredential,
   ChainedTokenCredential,
   ClientSecretCredential,
   DeviceCodeCredential,
@@ -62,8 +63,12 @@ export async function authenticateWithAzureIdentity(details: LoginDetails = {}, 
 
   const environmentCredential = new EnvironmentCredential();
 
+  const azureCliCredential = new AzureCliCredential();
+
   // Only use interactive browser credential if we're not running in docker
-  const credentials = isRunningInDocker() ? [environmentCredential, deviceCredential] : [environmentCredential, browserCredential, deviceCredential];
+  const credentials = isRunningInDocker()
+    ? [azureCliCredential, environmentCredential, deviceCredential]
+    : [azureCliCredential, environmentCredential, browserCredential, deviceCredential];
 
   if (details.tenantId && details.clientId && details.clientSecret) {
     const clientSecretCredential = new ClientSecretCredential(details.tenantId, details.clientId, details.clientSecret, {

--- a/src/core/account.ts
+++ b/src/core/account.ts
@@ -63,12 +63,14 @@ export async function authenticateWithAzureIdentity(details: LoginDetails = {}, 
 
   const environmentCredential = new EnvironmentCredential();
 
-  const azureCliCredential = new AzureCliCredential();
+  const azureCliCredential = new AzureCliCredential({
+    tenantId: details.clientId,
+  });
 
   // Only use interactive browser credential if we're not running in docker
   const credentials = isRunningInDocker()
-    ? [azureCliCredential, environmentCredential, deviceCredential]
-    : [azureCliCredential, environmentCredential, browserCredential, deviceCredential];
+    ? [environmentCredential, azureCliCredential, deviceCredential]
+    : [environmentCredential, azureCliCredential, browserCredential, deviceCredential];
 
   if (details.tenantId && details.clientId && details.clientSecret) {
     const clientSecretCredential = new ClientSecretCredential(details.tenantId, details.clientId, details.clientSecret, {


### PR DESCRIPTION
The current static-web-apps-deploy task does not support Service Principal, so we always need to use tokens for deployment, but it is very time consuming to configure everything when deploying to multiple SWAs.

If the SWA CLI supports Azure CLI login (azure/login action), deployment would be very simple.

Close #751