### PR TITLE
Fixing globs in routes

### DIFF
--- a/src/core/utils/glob.spec.ts
+++ b/src/core/utils/glob.spec.ts
@@ -40,6 +40,10 @@ describe("glob functions", () => {
     it("glob = {foo,bar}.json", () => {
       expect(globToRegExp("{foo,bar}.json")).toBe("(foo|bar).json");
     });
+
+    it("glob = /foo*", () => {
+      expect(globToRegExp("/foo*")).toBe("\\/foo.*");
+    });
   });
 
   // describe isValidGlobExpression

--- a/src/core/utils/glob.spec.ts
+++ b/src/core/utils/glob.spec.ts
@@ -26,19 +26,19 @@ describe("glob functions", () => {
     });
 
     it("glob = /*.{ext}", () => {
-      expect(globToRegExp("/*.{ext}")).toBe("\\/.*(ext)");
+      expect(globToRegExp("/*.{ext}")).toBe("\\/.*\\.(ext)");
     });
 
     it("glob = /*.{ext,gif}", () => {
-      expect(globToRegExp("/*.{ext,gif}")).toBe("\\/.*(ext|gif)");
+      expect(globToRegExp("/*.{ext,gif}")).toBe("\\/.*\\.(ext|gif)");
     });
 
     it("glob = /foo/*.{ext,gif}", () => {
-      expect(globToRegExp("/foo/*.{ext,gif}")).toBe("\\/foo\\/.*(ext|gif)");
+      expect(globToRegExp("/foo/*.{ext,gif}")).toBe("\\/foo\\/.*\\.(ext|gif)");
     });
 
     it("glob = {foo,bar}.json", () => {
-      expect(globToRegExp("{foo,bar}.json")).toBe("(foo|bar).json");
+      expect(globToRegExp("{foo,bar}.json")).toBe("(foo|bar)\\.json");
     });
 
     it("glob = /foo*", () => {

--- a/src/core/utils/glob.ts
+++ b/src/core/utils/glob.ts
@@ -31,7 +31,7 @@ export function globToRegExp(glob: string | undefined) {
     }
   }
 
-  return glob.replace(/\//g, "\\/").replace("*.", ".*").replace("/*", "/.*");
+  return glob.replace(/\//g, "\\/").replace(".", "\\.").replace("*", ".*");
 }
 
 /**


### PR DESCRIPTION
This pull request includes changes to improve the behavior of the `globToRegExp` function in the `src/core/utils/glob.ts` file. The function now correctly interprets the `*` character as a wildcard and escapes the `.` character to match a literal dot. Additionally, the expected result in the test case for `globToRegExp` was modified to reflect the updated behavior of the function.

Main changes:

* <a href="diffhunk://#diff-4f67ff1b15af7954b8fdc82ec6b1a29561869106f77b67fd27158d7912647ceeL34-R34">`src/core/utils/glob.ts`</a>: Modified the `globToRegExp` function to correctly interpret the `*` character as a wildcard and escape the `.` character to match a literal dot.
* <a href="diffhunk://#diff-229fad7787c95a066a1a02adc4b884a1700f3c4b5fd5cd555718c494c652a627L29-R45">`src/core/utils/glob.spec.ts`</a>: Modified the expected result in the test case for `globToRegExp` to include the escaped dot character (`\.`) to match the updated behavior of the function.

Fixes #792