### PR TITLE
add config schema option

### DIFF
--- a/src/cli/commands/init/init.spec.ts
+++ b/src/cli/commands/init/init.spec.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import mockFs from "mock-fs";
 import { init } from "./init";
 import { DEFAULT_CONFIG } from "../../../config";
-import { swaCliConfigFilename, swaCliConfigSchemaUrl } from "../../../core/utils";
+import { swaCliConfigFilename } from "../../../core/utils";
 import { convertToNativePaths, convertToUnixPaths } from "../../../jest.helpers.";
 
 jest.mock("prompts", () => jest.fn());

--- a/src/cli/commands/init/init.spec.ts
+++ b/src/cli/commands/init/init.spec.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import mockFs from "mock-fs";
 import { init } from "./init";
 import { DEFAULT_CONFIG } from "../../../config";
-import { swaCliConfigFilename } from "../../../core/utils";
+import { swaCliConfigFilename, swaCliConfigSchemaUrl } from "../../../core/utils";
 import { convertToNativePaths, convertToUnixPaths } from "../../../jest.helpers.";
 
 jest.mock("prompts", () => jest.fn());
@@ -23,6 +23,7 @@ const defautResolvedPrompts = {
   appDevserverUrl: "http://localhost:3000",
   apiDevserverUrl: "http://localhost:4040",
   confirmOverwrite: true,
+  schemaUrl: "https://json.schemastore.org/staticwebapp.config.json",
 };
 
 describe("swa init", () => {

--- a/src/cli/commands/start/register.ts
+++ b/src/cli/commands/start/register.ts
@@ -41,6 +41,7 @@ export default function registerCommand(program: Command) {
     )
     .option("-o, --open", "open the browser to the dev server", DEFAULT_CONFIG.open)
     .option("-f, --func-args <funcArgs>", "pass additional arguments to the func start command")
+    .option("-sc, --schema <schemaUrl>", "URL to the custom schema for staticwebapp.config.json", DEFAULT_CONFIG.schemaUrl)
     .action(async (positionalArg: string | undefined, _options: SWACLIConfig, command: Command) => {
       positionalArg = positionalArg?.trim();
       const options = await configureOptions(positionalArg, command.optsWithGlobals(), command, "start");

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,7 @@ const {
   SWA_CLI_DATA_API_FOLDER,
   SWA_CLI_API_LANGUAGE,
   SWA_CLI_API_VERSION,
+  SWA_CLI_CONFIG_SCHEMA_LOCATION,
 } = swaCLIEnv();
 
 export const DEFAULT_CONFIG: SWACLIConfig = {
@@ -59,6 +60,7 @@ export const DEFAULT_CONFIG: SWACLIConfig = {
   verbose: SWA_CLI_DEBUG || "log",
   devserverTimeout: parseInt(SWA_CLI_SERVER_TIMEOUT || "60", 10),
   open: useEnvVarOrUseDefault(SWA_CLI_OPEN_BROWSER, false),
+  schemaUrl: SWA_CLI_CONFIG_SCHEMA_LOCATION || undefined,
   githubActionWorkflowLocation: SWA_RUNTIME_WORKFLOW_LOCATION ? SWA_RUNTIME_WORKFLOW_LOCATION : undefined,
   appDevserverUrl: SWA_CLI_APP_DEVSERVER_URL || undefined,
   apiDevserverUrl: SWA_CLI_API_DEVSERVER_URL || undefined,

--- a/src/core/utils/user-config.ts
+++ b/src/core/utils/user-config.ts
@@ -166,7 +166,7 @@ function findLineAndColumnByPosition(content: string, position: number | undefin
 }
 
 async function loadSWAConfigSchema(): Promise<JSONSchemaType<SWACLIConfigFile> | null> {
-  const schemaUrl = DEFAULT_CONFIG.schemaUrl || "https://aka.ms/azure/static-web-apps-cli/schema";
+  const schemaUrl = DEFAULT_CONFIG.schemaUrl || "https://json.schemastore.org/staticwebapp.config.json";
   try {
     const res = await fetch(schemaUrl, { timeout: 10 * 1000 } as RequestInit);
     if (res.status === 200) {

--- a/src/core/utils/user-config.ts
+++ b/src/core/utils/user-config.ts
@@ -8,6 +8,7 @@ import path from "path";
 import { SWA_CONFIG_FILENAME, SWA_CONFIG_FILENAME_LEGACY, SWA_RUNTIME_CONFIG_MAX_SIZE_IN_KB } from "../constants";
 import { logger } from "./logger";
 import { isHttpUrl } from "./net";
+import { DEFAULT_CONFIG } from "../../config";
 const { readdir, readFile, stat } = fs.promises;
 
 /**
@@ -165,7 +166,7 @@ function findLineAndColumnByPosition(content: string, position: number | undefin
 }
 
 async function loadSWAConfigSchema(): Promise<JSONSchemaType<SWACLIConfigFile> | null> {
-  const schemaUrl = "https://json.schemastore.org/staticwebapp.config.json";
+  const schemaUrl = DEFAULT_CONFIG.schemaUrl || "https://aka.ms/azure/static-web-apps-cli/schema";
   try {
     const res = await fetch(schemaUrl, { timeout: 10 * 1000 } as RequestInit);
     if (res.status === 200) {

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -51,6 +51,7 @@ declare interface SWACLIEnv extends StaticSiteClientEnv {
   SWA_CLI_APP_DEVSERVER_URL?: string;
   SWA_CLI_API_DEVSERVER_URL?: string;
   SWA_CLI_DATA_API_DEVSERVER_URL?: string;
+  SWA_CLI_CONFIG_SCHEMA_LOCATION?: string;
 
   // swa deploy
   SWA_CLI_DEPLOY_DRY_RUN?: string;
@@ -152,6 +153,7 @@ declare type SWACLIStartOptions = {
   run?: string;
   devserverTimeout?: number;
   open?: boolean;
+  schemaUrl?: string;
   funcArgs?: string;
   githubActionWorkflowLocation?: string;
   swaConfigLocation?: string;


### PR DESCRIPTION
How about adding an option to specify the JsonSchema distribution part, which often causes problems in issues like the one below.

Issue: https://github.com/Azure/static-web-apps-cli/issues/754


I imagine the following command as how to use it.

```bash
swa start --schema "https://[alterbaseurl]/staticwebapp.config.json"
```