### PR TITLE
feat: support dotnet-isolated 8.0 for managed APIs

### DIFF
--- a/schema/staticwebapp.config.json
+++ b/schema/staticwebapp.config.json
@@ -589,6 +589,7 @@
             "dotnet:6.0",
             "dotnet-isolated:6.0",
             "dotnet-isolated:7.0",
+            "dotnet-isolated:8.0",
             "node:12",
             "node:14",
             "node:16",

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -240,7 +240,7 @@ export const DEFAULT_VERSION = {
 export const SUPPORTED_VERSIONS = {
   Node: ["12", "14", "16", "18"],
   Dotnet: ["3.1", "6.0"],
-  DotnetIsolated: ["6.0", "7.0"],
+  DotnetIsolated: ["6.0", "7.0", "8.0"],
   Python: ["3.8", "3.9", "3.10"],
 };
 


### PR DESCRIPTION
Supported dotnet-isolated 8.0 for managed APIs by:
- Updated staticwebapp.config.json schema to support dotnet-isolated:8.0 in "platform" for swa start and deploy. Will also Updated the version on [https://json.schemastore.org/staticwebapp.config.json](https://json.schemastore.org/staticwebapp.config.json).
- Supported choosing API version: dotnet-isolated:8.0 for swa init.