### PR TITLE
fix: Allow SKU selection when creating a new site on "swa deploy"

### DIFF
--- a/src/core/account.ts
+++ b/src/core/account.ts
@@ -15,7 +15,7 @@ import chalk from "chalk";
 import ora from "ora";
 import path from "path";
 import { swaCLIEnv } from "./env";
-import { chooseProjectName, chooseStaticSite, wouldYouLikeToCreateStaticSite, wouldYouLikeToOverrideStaticSite } from "./prompts";
+import { chooseProjectName, chooseProjectSku, chooseStaticSite, wouldYouLikeToCreateStaticSite, wouldYouLikeToOverrideStaticSite } from "./prompts";
 import { swaCliPersistencePlugin } from "./swa-cli-persistence-plugin";
 import { SWACLIPersistenceCachePlugin } from "./swa-cli-persistence-plugin/persistence-cache-plugin";
 import { dasherize, logger } from "./utils";
@@ -125,6 +125,7 @@ async function createStaticSite(options: SWACLIConfig, credentialChain: TokenCre
   const defaultStaticSiteName = appName || dasherize(path.basename(process.cwd())).substring(0, maxProjectNameLength);
 
   appName = await chooseProjectName(defaultStaticSiteName, maxProjectNameLength);
+  const sku = await chooseProjectSku();
   resourceGroup = resourceGroup || `${appName}-rg`;
 
   let spinner = ora("Creating a new project...").start();
@@ -144,7 +145,7 @@ async function createStaticSite(options: SWACLIConfig, credentialChain: TokenCre
 
     const staticSiteEnvelope: StaticSiteARMResource = {
       location: AZURE_REGION_LOCATION || DEFAULT_AZURE_LOCATION,
-      sku: { name: "Free", tier: "Free" },
+      sku: { name: sku, tier: sku },
 
       // these are mandatory, otherwise the static site will not be created
       buildProperties: {

--- a/src/core/prompts.ts
+++ b/src/core/prompts.ts
@@ -74,6 +74,18 @@ export async function chooseProjectName(initial: string, maxLength: number): Pro
   return response.projectName;
 }
 
+export async function chooseProjectSku(): Promise<string> {
+  const response = await promptOrUseDefault(false, {
+    type: "text",
+    name: "sku",
+    message: "Choose a SKU:",
+    initial: "Free",
+    validate: (value: string) => value === "Free" || value === "Standard" || "Configuration name cannot be empty",
+  });
+
+  return response.sku;
+}
+
 export async function chooseTenant(tenants: TenantIdDescription[], initial?: string): Promise<TenantIdDescription | undefined> {
   const choices = tenants.map((tenant) => ({
     title: tenant.tenantId as string,


### PR DESCRIPTION
Currently, when you create a new site via "swa deploy", the CLI always creates a "Free" sku site, but this PR introduces a sku picker that defaults to Free, but allows SKU selection during site creation. This is especially helpful to those who have hit the 5 free site limit and want to create a new site.