### PR TITLE
fix: upload package to blob via Workload Identity Federation connection

### DIFF
--- a/.github/workflows/azuresdkdrop.yml
+++ b/.github/workflows/azuresdkdrop.yml
@@ -100,12 +100,18 @@ jobs:
       with:
           name: package
 
+    - name: 'Az CLI login'
+      uses: azure/login@v1
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
     - name: Upload to drop
       run: |
         ls -la
         PACKAGE_ID=`echo $(ls *.tgz) | sed -e 's/\.tgz$//'`
         echo $PACKAGE_ID
-        az storage blob upload -n azure-staticwebapps/npm/$PACKAGE_ID/$(ls *.tgz) -c drops -f $(ls *.tgz) --account-name $AZURE_SDK_STORAGE_ACCOUNT_NAME --account-key $AZURE_SDK_DROP_ACCESS_KEY
+        az storage blob upload -n azure-staticwebapps/npm/$PACKAGE_ID/$(ls *.tgz) -c drops -f $(ls *.tgz) --account-name $AZURE_SDK_STORAGE_ACCOUNT_NAME
       env:
         AZURE_SDK_STORAGE_ACCOUNT_NAME: ${{secrets.AZURE_SDK_STORAGE_ACCOUNT_NAME}}
-        AZURE_SDK_DROP_ACCESS_KEY: ${{secrets.AZURE_SDK_DROP_ACCESS_KEY}}


### PR DESCRIPTION
This PR is to fix "Copy to drop" job failure by changing the method to connect Azure storage from access key to managed identity. Referencing this doc: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure