### PR TITLE
Fix target core tool version detection when using Node 20

### DIFF
--- a/src/core/func-core-tools.ts
+++ b/src/core/func-core-tools.ts
@@ -54,7 +54,7 @@ export function isCoreToolsVersionCompatible(coreToolsVersion: number, nodeVersi
 
 export function detectTargetCoreToolsVersion(nodeVersion: number): number {
   // Pick the highest version that is compatible with the specified Node version
-  if (nodeVersion >= 14 && nodeVersion <= 18) return 4;
+  if (nodeVersion >= 14 && nodeVersion <= 20) return 4;
   if (nodeVersion >= 10 && nodeVersion < 14) return 3;
   if (nodeVersion >= 8 && nodeVersion < 10) return 2;
 


### PR DESCRIPTION
Resolves issue found while testing Node 20 & .NET 8 SWA deployments stating that Node 20 is not supported with Azure Functions Core Tools v4 which is not true 😄 

Docs: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4 

✖ Found Azure Functions Core Tools v4 which is incompatible with your current Node.js v20.8.1.
✖ See https://aka.ms/functions-node-versions for more information.