### PR TITLE
Remove the second server.listen so that it also works with Node 20.13

### DIFF
--- a/src/msha/server.ts
+++ b/src/msha/server.ts
@@ -3,7 +3,6 @@ import fs from "fs";
 import http from "http";
 import httpProxy from "http-proxy";
 import https from "https";
-import internalIp from "internal-ip";
 import net from "net";
 import open from "open";
 import { DEFAULT_CONFIG } from "../config";
@@ -146,7 +145,6 @@ function onServerStart(server: https.Server | http.Server, socketConnection: net
 // start SWA proxy server
 (async () => {
   let socketConnection: net.Socket | undefined;
-  const localIpAdress = await internalIp.v4();
 
   // load user custom rules if running in local mode (non-dev server)
   let userConfig: SWAConfigFile | undefined;
@@ -171,5 +169,4 @@ function onServerStart(server: https.Server | http.Server, socketConnection: net
 
   const server = createServer();
   server.listen(Number(SWA_CLI_PORT), hostnameToIpAdress(DEFAULT_CONFIG.host), onServerStart(server, socketConnection));
-  server.listen(Number(SWA_CLI_PORT), localIpAdress);
 })();


### PR DESCRIPTION
ref: https://github.com/Azure/static-web-apps-cli/issues/829

Since Node 20.13, the behavior of `Server.listen` has changed.
The last listen will activate.
see: https://github.com/nodejs/node/issues/53204

The SWA CLI used to listen for localhost and listen for localIpAdress (access from the same network), but in Node 18 and 20, the latter listen for localIpAdress does not seem to work anymore.
Only localhost listen is performed under 20.13.

Currently only the latter process is used in Node 20.13 environments, so only localIpAdress access is available.

Therefore, this PR will be adapted to the behavior under Node 20.13 so that it can be accessed by localhost and so on.

I think it is better to consider how to make it accessible via localIpAdress from the same network in a new PR.

Testing with this change can be verified with `npm run e2e:static`. (This is the e2e test that is currently disabled)