### PR TITLE
Remove duplicate azure/login@v1 step in azuresdkdrop workflow

### DIFF
--- a/.github/workflows/azuresdkdrop.yml
+++ b/.github/workflows/azuresdkdrop.yml
@@ -100,13 +100,6 @@ jobs:
       with:
           name: package
           
-    - name: 'Az CLI login'
-      uses: azure/login@v1
-      with:
-        client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
     # Login via OIDC to permit uploading to azure drops blob store
     - name: 'Az login'
       uses: azure/login@v2


### PR DESCRIPTION
Removing duplicate step from old workflow file that will cause the OIDC Azure login to fail due to new Federation standards