### PR TITLE
Update azuresdkdrop workflow account-name

### DIFF
--- a/.github/workflows/azuresdkdrop.yml
+++ b/.github/workflows/azuresdkdrop.yml
@@ -108,9 +108,11 @@ jobs:
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+    # Deploy npm package - this is done by uploading to Azure's SDK blob storage then triggering their partner release pipeline.
+    # More info: https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/1/Partner-Release-Pipeline
     - name: Upload to drop
       run: |
         ls -la
         PACKAGE_ID=`echo $(ls *.tgz) | sed -e 's/\.tgz$//'`
         echo $PACKAGE_ID
-        az storage blob upload -n azure-staticwebapps/npm/$PACKAGE_ID/$(ls *.tgz) -c drops -f $(ls *.tgz) --account-name $AZURE_SDK_STORAGE_ACCOUNT_NAME
+        az storage blob upload -n azure-staticwebapps/npm/$PACKAGE_ID/$(ls *.tgz) -c drops -f $(ls *.tgz) --account-name azuresdkpartnerdrops


### PR DESCRIPTION
The azuresdkdrop action was throwing this error due to an unknown environment variable:
```
ERROR: argument --account-name: expected one argument

Examples from AI knowledge base:
az storage blob upload --account-name mystorageaccount --account-key 0000-0000 --container-name mycontainer --file /path/to/file --name myblob
Upload a file to a storage blob. (autogenerated)
```

Fixing this error by hardcoding the `azuresdkpartnerdrops` account name used by all Azure SDK partner release drop pipelines