### PR TITLE
fix(cli): Fix VuePress swa init and start

### DIFF
--- a/src/core/frameworks/frameworks.ts
+++ b/src/core/frameworks/frameworks.ts
@@ -188,10 +188,10 @@ export const appFrameworks: FrameworkDefinition[] = [
     overrides: ["vue"],
     packages: ["vuepress"],
     config: {
-      appBuildCommand: "npm run build",
-      appDevserverCommand: "npm run dev",
+      appBuildCommand: "npm run docs:build",
+      appDevserverCommand: "npm run docs:dev",
       appDevserverUrl: "http://localhost:8080",
-      outputLocation: "src/.vuepress/dist",
+      outputLocation: "docs/.vuepress/dist",
     },
   },
   {

--- a/src/core/utils/cli.ts
+++ b/src/core/utils/cli.ts
@@ -87,6 +87,8 @@ export function createStartupScriptCommand(startupScript: string, options: SWACL
       return `${npmOrYarnBin} run ${npmOrYarnScript.join(":")} --if-present`;
     } else if (["npx"].includes(npmOrYarnBin)) {
       return `${npmOrYarnBin} ${npmOrYarnScript.join(":")}`;
+    } else if (npmOrYarnBin.startsWith("npm run") && npmOrYarnScript.length === 1) {
+      return `${npmOrYarnBin}:${npmOrYarnScript} --if-present`;
     }
   } else {
     if (!path.isAbsolute(startupScript)) {


### PR DESCRIPTION
Commit contains fix to properly set the Vuepress start, build, and dist output properly when initializing the swa-cli.config.json file. Also contains fix where the Vuepress start command was not properly initialized when running "swa start" due to a colon being in the run command.

Fixes #849