### PR TITLE
Update 1-install.md

### DIFF
--- a/docs/www/docs/use/1-install.md
+++ b/docs/www/docs/use/1-install.md
@@ -6,9 +6,6 @@ sidebar_position: 1
 
 You can install the Static Web Apps CLI using [`npm`](https://docs.npmjs.com/cli/v6/commands/npm-install), [`yarn`](https://classic.yarnpkg.com/lang/en/docs/cli/install/) or [`pnpm`](https://pnpm.io/cli/install).
 
-:::info Note
-SWA CLI currently only supports runtime Node versions 16 and below. Kindly check and set your runtime to the same in order to have a smooth SWA CLI experience.
-
 :::
 
 ## Installing the CLI


### PR DESCRIPTION
As of [release 1.1.10](https://github.com/Azure/static-web-apps-cli/releases/tag/v1.1.10) Node 20.13 is now supported so this warning is no longer necessary.
