### PR TITLE
fix (#859): Add check for azureProfile.json to prevent double login

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -272,3 +272,8 @@ export function IS_DATA_API_DEV_SERVER() {
 export function SWA_CLI_DATA_API_URI() {
   return IS_DATA_API_DEV_SERVER() ? DEFAULT_CONFIG.dataApiLocation : address(DEFAULT_CONFIG.host, DEFAULT_CONFIG.dataApiPort, "http");
 }
+
+// Constants related to swa login
+const azureFolderName = ".azure";
+const azureProfileFilename = "azureProfile.json";
+export const AZURE_LOGIN_CONFIG = path.join(os.homedir(), azureFolderName, azureProfileFilename);

--- a/src/core/utils/file.ts
+++ b/src/core/utils/file.ts
@@ -7,7 +7,7 @@ export async function safeReadJson(path: string): Promise<JsonData | undefined> 
   try {
     let contents = await fs.readFile(path, "utf8");
     contents = stripJsonComments(contents);
-    return JSON.parse(contents) as JsonData;
+    return JSON.parse(contents.trim()) as JsonData;
   } catch (error) {
     logger.warn(`Failed to read JSON file at: ${path}`);
     return undefined;

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -407,3 +407,27 @@ declare type RolesSourceClaim = {
   typ: string;
   val: string;
 };
+
+declare type SubscriptionState = "Enabled" | "Warned" | "PastDue" | "Disabled" | "Deleted";
+
+declare type AzureLoginInfo = {
+  id: string;
+  name: string;
+  state: SubscriptionState;
+  user: {
+    name: string;
+    type: string;
+  };
+  isDefault: boolean;
+  tenantId: string;
+  environmentName: string;
+  homeTenantId: string;
+  tenantDefaultDomain: string;
+  tenantDisplayName: string;
+  managedByTenants: string[];
+};
+
+declare interface AzureProfile {
+  installationId: string;
+  subscriptions: AzureLoginInfo[];
+}


### PR DESCRIPTION
Fixes #859. 

Added an additional check in `swa login` command to check if `~\.azure\azureProfile.json` exists. If it exists, we can parse the currently selected subscriptionId and tenantId to pass into the `swa login` command to prevent another unnecessary selection in the picker. 