### PR TITLE
[Fix] Show "swa start" output in console

### DIFF
--- a/src/cli/commands/start/start.ts
+++ b/src/cli/commands/start/start.ts
@@ -348,7 +348,7 @@ export async function start(options: SWACLIConfig) {
     },
   });
 
-  const concurrentlyOptions: Partial<ConcurrentlyOptions> = { restartTries: 0, killOthers: ["failure", "success"] };
+  const concurrentlyOptions: Partial<ConcurrentlyOptions> = { restartTries: 0, killOthers: ["failure", "success"], raw: true };
   const { result } = concurrently(concurrentlyCommands, concurrentlyOptions);
 
   await result


### PR DESCRIPTION
After the most recent PR, "swa start" is still working but the output message with the emulator port 4280 link stop appearing. However it still works if I manually navigate to http://localhost:4280/.
 
Current main branch:
![image](https://github.com/user-attachments/assets/9fabb7b5-69ba-4d70-b649-e7930d53c609)

After fix:
![image](https://github.com/user-attachments/assets/20c04f33-e30c-49e3-bca7-5cecdad0d18b)
