### PR TITLE
Replace codeowners with current maintainers list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # These owners will be the default owners for everything in the repo
-*       @manekinekko @v1212 @cjk7989 @IvanJobs
+*       @Timothyw0 @cjk7989


### PR DESCRIPTION
This replaces the codeowners with the current maintainers list.