### PR TITLE
Refreshing Node.js supported versions

### DIFF
--- a/src/core/func-core-tools.spec.ts
+++ b/src/core/func-core-tools.spec.ts
@@ -53,46 +53,57 @@ describe("funcCoreTools", () => {
 
   describe("fct.isCoreToolsVersionCompatible()", () => {
     it("should return true for compatible versions", () => {
-      expect(fct.isCoreToolsVersionCompatible(4, 10)).toBe(false);
-      expect(fct.isCoreToolsVersionCompatible(3, 10)).toBe(true);
+      expect(fct.isCoreToolsVersionCompatible(3, 10)).toBe(false);
       expect(fct.isCoreToolsVersionCompatible(2, 10)).toBe(true);
-      expect(fct.isCoreToolsVersionCompatible(3, 11)).toBe(true);
-      expect(fct.isCoreToolsVersionCompatible(2, 11)).toBe(false);
+      expect(fct.isCoreToolsVersionCompatible(3, 11)).toBe(false);
+      expect(fct.isCoreToolsVersionCompatible(2, 11)).toBe(true);
       expect(fct.isCoreToolsVersionCompatible(4, 12)).toBe(false);
-      expect(fct.isCoreToolsVersionCompatible(3, 12)).toBe(true);
-      expect(fct.isCoreToolsVersionCompatible(2, 12)).toBe(false);
-      expect(fct.isCoreToolsVersionCompatible(3, 13)).toBe(true);
-      expect(fct.isCoreToolsVersionCompatible(4, 14)).toBe(true);
+      expect(fct.isCoreToolsVersionCompatible(3, 12)).toBe(false);
+      expect(fct.isCoreToolsVersionCompatible(2, 12)).toBe(true);
+      expect(fct.isCoreToolsVersionCompatible(4, 13)).toBe(false);
+      expect(fct.isCoreToolsVersionCompatible(3, 13)).toBe(false);
+      expect(fct.isCoreToolsVersionCompatible(2, 13)).toBe(true);
+      expect(fct.isCoreToolsVersionCompatible(4, 14)).toBe(false);
       expect(fct.isCoreToolsVersionCompatible(3, 14)).toBe(true);
-      expect(fct.isCoreToolsVersionCompatible(2, 14)).toBe(false);
-      expect(fct.isCoreToolsVersionCompatible(4, 15)).toBe(true);
-      expect(fct.isCoreToolsVersionCompatible(3, 15)).toBe(false);
-      expect(fct.isCoreToolsVersionCompatible(4, 16)).toBe(true);
-      expect(fct.isCoreToolsVersionCompatible(3, 16)).toBe(false);
+      expect(fct.isCoreToolsVersionCompatible(2, 14)).toBe(true);
+      expect(fct.isCoreToolsVersionCompatible(4, 15)).toBe(false);
+      expect(fct.isCoreToolsVersionCompatible(3, 15)).toBe(true);
+      expect(fct.isCoreToolsVersionCompatible(4, 16)).toBe(false);
+      expect(fct.isCoreToolsVersionCompatible(3, 16)).toBe(true);
       expect(fct.isCoreToolsVersionCompatible(2, 16)).toBe(false);
-      expect(fct.isCoreToolsVersionCompatible(4, 17)).toBe(true);
-      expect(fct.isCoreToolsVersionCompatible(3, 17)).toBe(false);
+      expect(fct.isCoreToolsVersionCompatible(4, 17)).toBe(false);
+      expect(fct.isCoreToolsVersionCompatible(3, 17)).toBe(true);
       expect(fct.isCoreToolsVersionCompatible(2, 17)).toBe(false);
       expect(fct.isCoreToolsVersionCompatible(4, 18)).toBe(true);
-      expect(fct.isCoreToolsVersionCompatible(3, 18)).toBe(false);
+      expect(fct.isCoreToolsVersionCompatible(3, 18)).toBe(true);
       expect(fct.isCoreToolsVersionCompatible(2, 18)).toBe(false);
+      expect(fct.isCoreToolsVersionCompatible(4, 19)).toBe(true);
+      expect(fct.isCoreToolsVersionCompatible(3, 19)).toBe(true);
+      expect(fct.isCoreToolsVersionCompatible(2, 19)).toBe(false);
+      expect(fct.isCoreToolsVersionCompatible(4, 20)).toBe(true);
+      expect(fct.isCoreToolsVersionCompatible(3, 20)).toBe(true);
+      expect(fct.isCoreToolsVersionCompatible(2, 20)).toBe(false);
     });
   });
 
   describe("detectTargetCoreToolsVersion()", () => {
     it("should return the latest valid version for each Node version", () => {
-      expect(fct.detectTargetCoreToolsVersion(8)).toBe(2);
-      expect(fct.detectTargetCoreToolsVersion(9)).toBe(2);
-      expect(fct.detectTargetCoreToolsVersion(10)).toBe(3);
-      expect(fct.detectTargetCoreToolsVersion(11)).toBe(3);
-      expect(fct.detectTargetCoreToolsVersion(12)).toBe(3);
-      expect(fct.detectTargetCoreToolsVersion(13)).toBe(3);
-      expect(fct.detectTargetCoreToolsVersion(14)).toBe(4);
-      expect(fct.detectTargetCoreToolsVersion(15)).toBe(4);
-      expect(fct.detectTargetCoreToolsVersion(16)).toBe(4);
+      expect(fct.detectTargetCoreToolsVersion(10)).toBe(2);
+      expect(fct.detectTargetCoreToolsVersion(11)).toBe(2);
+      expect(fct.detectTargetCoreToolsVersion(12)).toBe(2);
+      expect(fct.detectTargetCoreToolsVersion(13)).toBe(2);
+      expect(fct.detectTargetCoreToolsVersion(14)).toBe(3);
+      expect(fct.detectTargetCoreToolsVersion(15)).toBe(3);
+      expect(fct.detectTargetCoreToolsVersion(16)).toBe(3);
+      expect(fct.detectTargetCoreToolsVersion(17)).toBe(3);
+      expect(fct.detectTargetCoreToolsVersion(18)).toBe(4);
+      expect(fct.detectTargetCoreToolsVersion(19)).toBe(4);
+      expect(fct.detectTargetCoreToolsVersion(20)).toBe(4);
       // Unsupported Node versions should always return the latest version
+      expect(fct.detectTargetCoreToolsVersion(8)).toBe(4);
+      expect(fct.detectTargetCoreToolsVersion(9)).toBe(4);
       expect(fct.detectTargetCoreToolsVersion(7)).toBe(4);
-      expect(fct.detectTargetCoreToolsVersion(17)).toBe(4);
+      expect(fct.detectTargetCoreToolsVersion(21)).toBe(4);
     });
   });
 
@@ -213,7 +224,7 @@ describe("funcCoreTools", () => {
     });
 
     it("should return the downloaded binary if the system binary is incompatible", async () => {
-      fct.setCachedInstalledSystemCoreToolsVersion(3);
+      fct.setCachedInstalledSystemCoreToolsVersion(2);
 
       vol.fromNestedJSON({
         ["/home/user/.swa/core-tools/v4"]: { ".release-version": "4.3.2" },
@@ -256,7 +267,7 @@ describe("funcCoreTools", () => {
         {
           ["/home/user/.swa/core-tools/"]: {},
         },
-        "/home/user"
+        "/home/user",
       );
 
       const binary = await fct.getCoreToolsBinary();

--- a/src/core/func-core-tools.ts
+++ b/src/core/func-core-tools.ts
@@ -42,11 +42,11 @@ export function isCoreToolsVersionCompatible(coreToolsVersion: number, nodeVersi
   // Runtime support reference: https://docs.microsoft.com/azure/azure-functions/functions-versions?pivots=programming-language-javascript#languages
   switch (coreToolsVersion) {
     case 4:
-      return nodeVersion >= 14 && nodeVersion <= 20;
+      return nodeVersion >= 18 && nodeVersion <= 20;
     case 3:
-      return nodeVersion >= 10 && nodeVersion <= 14;
+      return nodeVersion >= 14 && nodeVersion <= 20;
     case 2:
-      return nodeVersion >= 8 && nodeVersion <= 10;
+      return nodeVersion >= 10 && nodeVersion <= 14;
     default:
       return false;
   }
@@ -54,9 +54,9 @@ export function isCoreToolsVersionCompatible(coreToolsVersion: number, nodeVersi
 
 export function detectTargetCoreToolsVersion(nodeVersion: number): number {
   // Pick the highest version that is compatible with the specified Node version
-  if (nodeVersion >= 14 && nodeVersion <= 20) return 4;
-  if (nodeVersion >= 10 && nodeVersion < 14) return 3;
-  if (nodeVersion >= 8 && nodeVersion < 10) return 2;
+  if (nodeVersion >= 18 && nodeVersion <= 20) return 4;
+  if (nodeVersion >= 14 && nodeVersion < 20) return 3;
+  if (nodeVersion >= 10 && nodeVersion < 14) return 2;
 
   // Fallback to the latest version for Unsupported Node version
   return 4;
@@ -92,9 +92,11 @@ async function getInstalledSystemCoreToolsVersion(): Promise<number | undefined>
 
 function getDownloadedCoreToolsVersion(targetVersion: number): string | undefined {
   const folder = getCoreToolsFolder(targetVersion);
+  console.log("DOWNLOAD", folder);
   if (!fs.existsSync(folder)) {
     return undefined;
   }
+  console.log("Ok folder exists");
 
   const versionFile = path.join(folder, VERSION_FILE);
   if (!fs.existsSync(versionFile)) {
@@ -155,7 +157,7 @@ async function downloadAndUnzipPackage(release: CoreToolsRelease, dest: string) 
     {
       format: "{bar} {percentage}% | ETA: {eta}s",
     },
-    cliProgress.Presets.shades_classic
+    cliProgress.Presets.shades_classic,
   );
   try {
     const response = await fetch(release.url);

--- a/src/core/func-core-tools.ts
+++ b/src/core/func-core-tools.ts
@@ -92,11 +92,9 @@ async function getInstalledSystemCoreToolsVersion(): Promise<number | undefined>
 
 function getDownloadedCoreToolsVersion(targetVersion: number): string | undefined {
   const folder = getCoreToolsFolder(targetVersion);
-  console.log("DOWNLOAD", folder);
   if (!fs.existsSync(folder)) {
     return undefined;
   }
-  console.log("Ok folder exists");
 
   const versionFile = path.join(folder, VERSION_FILE);
   if (!fs.existsSync(versionFile)) {


### PR DESCRIPTION
This PR includes the fixes in #786 and fixes the failing unit test.


Original PR: https://github.com/Azure/static-web-apps-cli/pull/786

Updating the supported node versions to match the [current list](https://learn.microsoft.com/en-gb/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#supported-versions), including previews.

Fixes https://github.com/Azure/static-web-apps-cli/issues/756