### PR TITLE
fix (#873, #864): Start crash including auth & Node 20 support

### DIFF
--- a/schema/staticwebapp.config.json
+++ b/schema/staticwebapp.config.json
@@ -594,6 +594,7 @@
             "node:14",
             "node:16",
             "node:18",
+            "node:20",
             "python:3.8",
             "python:3.9",
             "python:3.10"

--- a/src/msha/auth/index.ts
+++ b/src/msha/auth/index.ts
@@ -54,7 +54,7 @@ function getAuthPaths(isCustomAuth: boolean): Path[] {
       route: /^\/\.auth\/purge\/(?<provider>aad|github|twitter|google|facebook|[a-z]+)(\?.*)?$/i,
       // locally, all purge requests are processed as logout requests
       function: "auth-logout",
-    }
+    },
   );
 
   return paths;
@@ -62,7 +62,7 @@ function getAuthPaths(isCustomAuth: boolean): Path[] {
 
 async function routeMatcher(
   url = "/",
-  customAuth: SWAConfigFileAuth | undefined
+  customAuth: SWAConfigFileAuth | undefined,
 ): Promise<{ func: Function | undefined; bindingData: undefined | { provider: string } }> {
   const authPaths = getAuthPaths(!!customAuth);
   for (let index = 0; index < authPaths.length; index++) {
@@ -76,7 +76,7 @@ async function routeMatcher(
         };
       }
 
-      const func = (await import(`./routes/${path.function}`)).default as Function;
+      const func = (await import(`./routes/${path.function}.js`)).default as Function;
       return { func, bindingData };
     }
   }


### PR DESCRIPTION
Fixes #873: Update MSHA's authentication import statement to include the `.js` file extension when importing the proper authentication route.
![image](https://github.com/user-attachments/assets/f3d3a08b-ba29-4574-92f9-9d833a856835)


Fixes #864: Update the configschema to include Node 20 so using `"platform": {"apiRuntime": "node:20"}` in the staticwebapp.config.json no longer causes an error when starting the emulator.
![image](https://github.com/user-attachments/assets/caa7625e-dc80-4e67-ac40-10c57f5033d4)
