### PR TITLE
[Feature] Add AAD Custom Auth Support & Setup Custom Auth Framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,8 +134,8 @@
     ]
   },
   "engines": {
-    "node": ">=14.0.0",
-    "npm": ">=6.0.0"
+    "node": ">=18.0.0",
+    "npm": ">=9.0.0"
   },
   "release": {
     "branches": "main",

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -63,8 +63,8 @@ export const CUSTOM_AUTH_TOKEN_ENDPOINT_MAPPING: AuthIdentityTokenEndpoints = {
     path: "/login/oauth/access_token",
   },
   aad: {
-    host: "login.microsoft.com",
-    path: "/tenantId/oauth/v2.0/token",
+    host: "login.microsoftonline.com",
+    path: "/tenantId/oauth2/v2.0/token",
   },
 };
 export const CUSTOM_AUTH_USER_ENDPOINT_MAPPING: AuthIdentityTokenEndpoints = {

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -48,9 +48,44 @@ export const SWA_RUNTIME_CONFIG_MAX_SIZE_IN_KB = 20; // 20kb
 export const SWA_AUTH_CONTEXT_COOKIE = `StaticWebAppsAuthContextCookie`;
 export const SWA_AUTH_COOKIE = `StaticWebAppsAuthCookie`;
 export const ALLOWED_HTTP_METHODS_FOR_STATIC_CONTENT = ["GET", "HEAD", "OPTIONS"];
+
+// Custom Auth constants
 export const SUPPORTED_CUSTOM_AUTH_PROVIDERS = ["google", "github", "aad"];
 // Full name is required in staticwebapp.config.json's schema so we will normalize it to aad
 export const AAD_FULL_NAME = "azureActiveDirectory";
+export const CUSTOM_AUTH_TOKEN_ENDPOINT_MAPPING: AuthIdentityTokenEndpoints = {
+  google: {
+    host: "oauth2.googleapis.com",
+    path: "/token",
+  },
+  github: {
+    host: "github.com",
+    path: "/login/oauth/access_token",
+  },
+  aad: {
+    host: "login.microsoft.com",
+    path: "/tenantId/oauth/v2.0/token",
+  },
+};
+export const CUSTOM_AUTH_USER_ENDPOINT_MAPPING: AuthIdentityTokenEndpoints = {
+  google: {
+    host: "www.googleapis.com",
+    path: "/oauth2/v2/userinfo",
+  },
+  github: {
+    host: "api.github.com",
+    path: "/user",
+  },
+  aad: {
+    host: "graph.microsoft.com",
+    path: "/oidc/userinfo",
+  },
+};
+export const CUSTOM_AUTH_ISS_MAPPING: AuthIdentityIssHosts = {
+  google: "https://account.google.com",
+  github: "",
+  aad: "https://graph.microsoft.com",
+};
 
 export const AUTH_STATUS = {
   NoAuth: 0,

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -48,7 +48,9 @@ export const SWA_RUNTIME_CONFIG_MAX_SIZE_IN_KB = 20; // 20kb
 export const SWA_AUTH_CONTEXT_COOKIE = `StaticWebAppsAuthContextCookie`;
 export const SWA_AUTH_COOKIE = `StaticWebAppsAuthCookie`;
 export const ALLOWED_HTTP_METHODS_FOR_STATIC_CONTENT = ["GET", "HEAD", "OPTIONS"];
-export const SUPPORTED_CUSTOM_AUTH_PROVIDERS = ["google", "github", "azureActiveDirectory"];
+export const SUPPORTED_CUSTOM_AUTH_PROVIDERS = ["google", "github", "aad"];
+// Full name is required in staticwebapp.config.json's schema so we will normalize it to aad
+export const AAD_FULL_NAME = "azureActiveDirectory";
 
 export const AUTH_STATUS = {
   NoAuth: 0,

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -48,6 +48,7 @@ export const SWA_RUNTIME_CONFIG_MAX_SIZE_IN_KB = 20; // 20kb
 export const SWA_AUTH_CONTEXT_COOKIE = `StaticWebAppsAuthContextCookie`;
 export const SWA_AUTH_COOKIE = `StaticWebAppsAuthCookie`;
 export const ALLOWED_HTTP_METHODS_FOR_STATIC_CONTENT = ["GET", "HEAD", "OPTIONS"];
+export const SUPPORTED_CUSTOM_AUTH_PROVIDERS = ["google", "github", "azureActiveDirectory"];
 
 export const AUTH_STATUS = {
   NoAuth: 0,

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -50,9 +50,12 @@ export const SWA_AUTH_COOKIE = `StaticWebAppsAuthCookie`;
 export const ALLOWED_HTTP_METHODS_FOR_STATIC_CONTENT = ["GET", "HEAD", "OPTIONS"];
 
 // Custom Auth constants
-export const SUPPORTED_CUSTOM_AUTH_PROVIDERS = ["google", "github", "aad"];
-// Full name is required in staticwebapp.config.json's schema so we will normalize it to aad
-export const AAD_FULL_NAME = "azureActiveDirectory";
+export const SUPPORTED_CUSTOM_AUTH_PROVIDERS = ["google", "github", "aad", "dummy"];
+/*
+  The full name is required in staticwebapp.config.json's schema that will be normalized to aad
+  https://learn.microsoft.com/en-us/azure/static-web-apps/authentication-custom?tabs=aad%2Cinvitations
+*/
+export const ENTRAID_FULL_NAME = "azureActiveDirectory";
 export const CUSTOM_AUTH_TOKEN_ENDPOINT_MAPPING: AuthIdentityTokenEndpoints = {
   google: {
     host: "oauth2.googleapis.com",

--- a/src/msha/auth/index.ts
+++ b/src/msha/auth/index.ts
@@ -2,21 +2,24 @@ import type http from "node:http";
 import { serializeCookie } from "../../core/utils/cookie.js";
 import { logger } from "../../core/utils/logger.js";
 import { response as newResponse } from "../../core/utils/net.js";
+import { SUPPORTED_CUSTOM_AUTH_PROVIDERS } from "../../core/constants.js";
 
 function getAuthPaths(isCustomAuth: boolean): Path[] {
   const paths: Path[] = [];
 
   if (isCustomAuth) {
+    const supportedAuthsRegex = SUPPORTED_CUSTOM_AUTH_PROVIDERS.join("|");
+
     paths.push({
       method: "GET",
       // only match for providers with custom auth support implemented (github, google, aad)
-      route: /^\/\.auth\/login\/(?<provider>github|google|aad|dummy)\/callback(\?.*)?$/i,
+      route: new RegExp(`^/\\.auth/login/(?<provider>${supportedAuthsRegex})/callback(\\?.*)?$`, "i"),
       function: "auth-login-provider-callback",
     });
     paths.push({
       method: "GET",
       // only match for providers with custom auth support implemented (github, google, aad)
-      route: /^\/\.auth\/login\/(?<provider>github|google|aad|dummy)(\?.*)?$/i,
+      route: new RegExp(`^/\\.auth/login/(?<provider>${supportedAuthsRegex})(\\?.*)?$`, "i"),
       function: "auth-login-provider-custom",
     });
     paths.push({

--- a/src/msha/auth/index.ts
+++ b/src/msha/auth/index.ts
@@ -10,13 +10,13 @@ function getAuthPaths(isCustomAuth: boolean): Path[] {
     paths.push({
       method: "GET",
       // only match for providers with custom auth support implemented (github, google, aad)
-      route: /^\/\.auth\/login\/(?<provider>github|google|azureActiveDirectory|dummy)\/callback(\?.*)?$/i,
+      route: /^\/\.auth\/login\/(?<provider>github|google|aad|dummy)\/callback(\?.*)?$/i,
       function: "auth-login-provider-callback",
     });
     paths.push({
       method: "GET",
       // only match for providers with custom auth support implemented (github, google, aad)
-      route: /^\/\.auth\/login\/(?<provider>github|google|azureActiveDirectory|dummy)(\?.*)?$/i,
+      route: /^\/\.auth\/login\/(?<provider>github|google|aad|dummy)(\?.*)?$/i,
       function: "auth-login-provider-custom",
     });
     paths.push({

--- a/src/msha/auth/index.ts
+++ b/src/msha/auth/index.ts
@@ -9,20 +9,20 @@ function getAuthPaths(isCustomAuth: boolean): Path[] {
   if (isCustomAuth) {
     paths.push({
       method: "GET",
-      // only match for providers with custom auth support implemented (github, google)
-      route: /^\/\.auth\/login\/(?<provider>github|google|dummy)\/callback(\?.*)?$/i,
+      // only match for providers with custom auth support implemented (github, google, aad)
+      route: /^\/\.auth\/login\/(?<provider>github|google|azureActiveDirectory|dummy)\/callback(\?.*)?$/i,
       function: "auth-login-provider-callback",
     });
     paths.push({
       method: "GET",
-      // only match for providers with custom auth support implemented (github, google)
-      route: /^\/\.auth\/login\/(?<provider>github|google|dummy)(\?.*)?$/i,
+      // only match for providers with custom auth support implemented (github, google, aad)
+      route: /^\/\.auth\/login\/(?<provider>github|google|azureActiveDirectory|dummy)(\?.*)?$/i,
       function: "auth-login-provider-custom",
     });
     paths.push({
       method: "GET",
       // For providers with custom auth support not implemented, revert to old behavior
-      route: /^\/\.auth\/login\/(?<provider>aad|twitter|facebook|[a-z]+)(\?.*)?$/i,
+      route: /^\/\.auth\/login\/(?<provider>twitter|facebook|[a-z]+)(\?.*)?$/i,
       function: "auth-login-provider",
     });
     paths.push({
@@ -33,7 +33,7 @@ function getAuthPaths(isCustomAuth: boolean): Path[] {
   } else {
     paths.push({
       method: "GET",
-      route: /^\/\.auth\/login\/(?<provider>aad|github|twitter|google|facebook|[a-z]+)(\?.*)?$/i,
+      route: /^\/\.auth\/login\/(?<provider>github|twitter|google|facebook|[a-z]+)(\?.*)?$/i,
       function: "auth-login-provider",
     });
   }

--- a/src/msha/auth/routes/auth-login-provider-callback.ts
+++ b/src/msha/auth/routes/auth-login-provider-callback.ts
@@ -5,7 +5,7 @@ import * as querystring from "node:querystring";
 import { CookiesManager, decodeAuthContextCookie, validateAuthContextCookie } from "../../../core/utils/cookie.js";
 import { parseUrl, response } from "../../../core/utils/net.js";
 import {
-  AAD_FULL_NAME,
+  ENTRAID_FULL_NAME,
   CUSTOM_AUTH_ISS_MAPPING,
   CUSTOM_AUTH_TOKEN_ENDPOINT_MAPPING,
   CUSTOM_AUTH_USER_ENDPOINT_MAPPING,
@@ -335,7 +335,7 @@ const httpTrigger = async function (context: Context, request: http.IncomingMess
   }
 
   const { clientIdSettingName, clientSecretSettingName, openIdIssuer } =
-    customAuth?.identityProviders?.[providerName == "aad" ? AAD_FULL_NAME : providerName]?.registration || {};
+    customAuth?.identityProviders?.[providerName == "aad" ? ENTRAID_FULL_NAME : providerName]?.registration || {};
 
   if (!clientIdSettingName) {
     context.res = response({

--- a/src/msha/auth/routes/auth-login-provider-callback.ts
+++ b/src/msha/auth/routes/auth-login-provider-callback.ts
@@ -150,8 +150,8 @@ const getOAuthToken = function (authProvider: string, codeValue: string, clientI
     code: codeValue,
     client_id: clientId,
     client_secret: clientSecret,
-    ...(authProvider !== "github" && { grant_type: authProvider }),
-    ...(authProvider !== "github" && { redirect_uri: `${redirectUri}/.auth/login/${authProvider}/callback` }),
+    grant_type: "authorization_code",
+    redirect_uri: `${redirectUri}/.auth/login/${authProvider}/callback`,
   });
 
   let tokenPath = CUSTOM_AUTH_TOKEN_ENDPOINT_MAPPING?.[authProvider]?.path;

--- a/src/msha/auth/routes/auth-login-provider-callback.ts
+++ b/src/msha/auth/routes/auth-login-provider-callback.ts
@@ -30,7 +30,8 @@ const getAuthClientPrincipal = async function (
     const authTokenResponse = (await getOAuthToken(authProvider, codeValue!, clientId, clientSecret, openIdIssuer)) as string;
     const authTokenParsed = JSON.parse(authTokenResponse);
     authToken = authTokenParsed["access_token"] as string;
-  } catch {
+  } catch (error) {
+    console.error(`Error in getting OAuth token: ${error}`);
     return null;
   }
 
@@ -149,8 +150,8 @@ const getOAuthToken = function (authProvider: string, codeValue: string, clientI
     code: codeValue,
     client_id: clientId,
     client_secret: clientSecret,
-    grant_type: authProvider !== "github" && "authorization_code",
-    redirect_uri: authProvider !== "github" && `${redirectUri}/.auth/login/${authProvider}/callback`,
+    ...(authProvider !== "github" && { grant_type: authProvider }),
+    ...(authProvider !== "github" && { redirect_uri: `${redirectUri}/.auth/login/${authProvider}/callback` }),
   });
 
   let tokenPath = CUSTOM_AUTH_TOKEN_ENDPOINT_MAPPING?.[authProvider]?.path;
@@ -160,7 +161,7 @@ const getOAuthToken = function (authProvider: string, codeValue: string, clientI
 
   const options = {
     host: CUSTOM_AUTH_TOKEN_ENDPOINT_MAPPING?.[authProvider]?.host,
-    path: `/${tenantId}/oauth2/v2.0/token`,
+    path: tokenPath,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/src/msha/auth/routes/auth-login-provider-callback.ts
+++ b/src/msha/auth/routes/auth-login-provider-callback.ts
@@ -28,7 +28,12 @@ const getAuthClientPrincipal = async function (
 
   try {
     const authTokenResponse = (await getOAuthToken(authProvider, codeValue!, clientId, clientSecret, openIdIssuer)) as string;
-    const authTokenParsed = JSON.parse(authTokenResponse);
+    let authTokenParsed;
+    try {
+      authTokenParsed = JSON.parse(authTokenResponse);
+    } catch (e) {
+      authTokenParsed = querystring.parse(authTokenResponse);
+    }
     authToken = authTokenParsed["access_token"] as string;
   } catch (error) {
     console.error(`Error in getting OAuth token: ${error}`);

--- a/src/msha/auth/routes/auth-login-provider-custom.ts
+++ b/src/msha/auth/routes/auth-login-provider-custom.ts
@@ -1,12 +1,12 @@
 import { IncomingMessage } from "node:http";
 import { CookiesManager } from "../../../core/utils/cookie.js";
 import { response } from "../../../core/utils/net.js";
-import { AAD_FULL_NAME, SUPPORTED_CUSTOM_AUTH_PROVIDERS, SWA_CLI_APP_PROTOCOL } from "../../../core/constants.js";
+import { ENTRAID_FULL_NAME, SUPPORTED_CUSTOM_AUTH_PROVIDERS, SWA_CLI_APP_PROTOCOL } from "../../../core/constants.js";
 import { DEFAULT_CONFIG } from "../../../config.js";
 import { encryptAndSign, extractPostLoginRedirectUri, hashStateGuid, newNonceWithExpiration } from "../../../core/utils/auth.js";
 
 export const normalizeAuthProvider = (providerName?: string) => {
-  if (providerName === AAD_FULL_NAME) {
+  if (providerName === ENTRAID_FULL_NAME) {
     return "aad";
   }
   return providerName?.toLowerCase() || "";
@@ -28,7 +28,7 @@ const httpTrigger = async function (context: Context, request: IncomingMessage, 
   }
 
   const clientIdSettingName =
-    customAuth?.identityProviders?.[providerName == "aad" ? AAD_FULL_NAME : providerName]?.registration?.clientIdSettingName;
+    customAuth?.identityProviders?.[providerName == "aad" ? ENTRAID_FULL_NAME : providerName]?.registration?.clientIdSettingName;
 
   if (!clientIdSettingName) {
     context.res = response({
@@ -54,7 +54,7 @@ const httpTrigger = async function (context: Context, request: IncomingMessage, 
 
   let aadIssuer;
   if (providerName == "aad") {
-    aadIssuer = customAuth?.identityProviders?.[AAD_FULL_NAME]?.registration?.openIdIssuer;
+    aadIssuer = customAuth?.identityProviders?.[ENTRAID_FULL_NAME]?.registration?.openIdIssuer;
 
     if (!aadIssuer) {
       context.res = response({

--- a/src/msha/auth/routes/auth-login-provider-custom.ts
+++ b/src/msha/auth/routes/auth-login-provider-custom.ts
@@ -1,19 +1,19 @@
 import { IncomingMessage } from "node:http";
 import { CookiesManager } from "../../../core/utils/cookie.js";
 import { response } from "../../../core/utils/net.js";
-import { SWA_CLI_APP_PROTOCOL } from "../../../core/constants.js";
+import { SUPPORTED_CUSTOM_AUTH_PROVIDERS, SWA_CLI_APP_PROTOCOL } from "../../../core/constants.js";
 import { DEFAULT_CONFIG } from "../../../config.js";
 import { encryptAndSign, extractPostLoginRedirectUri, hashStateGuid, newNonceWithExpiration } from "../../../core/utils/auth.js";
 
 const httpTrigger = async function (context: Context, request: IncomingMessage, customAuth?: SWAConfigFileAuth) {
   await Promise.resolve();
 
-  const providerName = context.bindingData?.provider?.toLowerCase() || "";
+  const providerName: string = context.bindingData?.provider || "";
 
-  if (providerName != "github" && providerName != "google") {
+  if (!SUPPORTED_CUSTOM_AUTH_PROVIDERS.includes(providerName)) {
     context.res = response({
       context,
-      status: 404,
+      status: 400,
       headers: { ["Content-Type"]: "text/plain" },
       body: `Provider '${providerName}' not found`,
     });
@@ -25,7 +25,7 @@ const httpTrigger = async function (context: Context, request: IncomingMessage, 
   if (!clientIdSettingName) {
     context.res = response({
       context,
-      status: 404,
+      status: 400,
       headers: { ["Content-Type"]: "text/plain" },
       body: `ClientIdSettingName not found for '${providerName}' provider`,
     });
@@ -37,11 +37,26 @@ const httpTrigger = async function (context: Context, request: IncomingMessage, 
   if (!clientId) {
     context.res = response({
       context,
-      status: 404,
+      status: 400,
       headers: { ["Content-Type"]: "text/plain" },
       body: `ClientId not found for '${providerName}' provider`,
     });
     return;
+  }
+
+  let aadIssuer;
+  if (providerName == "azureActiveDirectory") {
+    aadIssuer = customAuth?.identityProviders?.[providerName]?.registration?.openIdIssuer;
+
+    if (!aadIssuer) {
+      context.res = response({
+        context,
+        status: 400,
+        headers: { ["Content-Type"]: "text/plain" },
+        body: `openIdIssuer not found for '${providerName}' provider`,
+      });
+      return;
+    }
   }
 
   const state = newNonceWithExpiration();
@@ -58,10 +73,20 @@ const httpTrigger = async function (context: Context, request: IncomingMessage, 
   const hashedState = hashStateGuid(state);
   const redirectUri = `${SWA_CLI_APP_PROTOCOL}://${DEFAULT_CONFIG.host}:${DEFAULT_CONFIG.port}`;
 
-  const location =
-    providerName === "google"
-      ? `https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=${clientId}&redirect_uri=${redirectUri}/.auth/login/google/callback&scope=openid+profile+email&state=${hashedState}`
-      : `https://github.com/login/oauth/authorize?response_type=code&client_id=${clientId}&redirect_uri=${redirectUri}/.auth/login/github/callback&scope=read:user&state=${hashedState}`;
+  let location;
+  switch (providerName) {
+    case "google":
+      location = `https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=${clientId}&redirect_uri=${redirectUri}/.auth/login/google/callback&scope=openid+profile+email&state=${hashedState}`;
+      break;
+    case "github":
+      location = `https://github.com/login/oauth/authorize?response_type=code&client_id=${clientId}&redirect_uri=${redirectUri}/.auth/login/github/callback&scope=read:user&state=${hashedState}`;
+      break;
+    case "azureActiveDirectory":
+      location = `${aadIssuer}/authorize?response_type=code&client_id=${clientId}&redirect_uri=${redirectUri}/.auth/login/azureActiveDirectory/callback&scope=openid&state=${hashedState}`;
+      break;
+    default:
+      break;
+  }
 
   const cookiesManager = new CookiesManager(request.headers.cookie);
   if (!authContextCookie) {

--- a/src/msha/auth/routes/auth-login-provider-custom.ts
+++ b/src/msha/auth/routes/auth-login-provider-custom.ts
@@ -90,7 +90,7 @@ const httpTrigger = async function (context: Context, request: IncomingMessage, 
       location = `https://github.com/login/oauth/authorize?response_type=code&client_id=${clientId}&redirect_uri=${redirectUri}/.auth/login/github/callback&scope=read:user&state=${hashedState}`;
       break;
     case "aad":
-      location = `${aadIssuer}/authorize?response_type=code&client_id=${clientId}&redirect_uri=${redirectUri}/.auth/login/aad/callback&scope=openid&state=${hashedState}`;
+      location = `${aadIssuer}/authorize?response_type=code&client_id=${clientId}&redirect_uri=${redirectUri}/.auth/login/aad/callback&scope=openid+profile+email&state=${hashedState}`;
       break;
     default:
       break;

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -95,7 +95,7 @@ declare interface Context {
         value: string;
         expires: string | Date;
         domaine: string;
-      }
+      },
     ];
     headers?: { [key: string]: string };
     body?: { [key: string]: string } | string | null;
@@ -294,17 +294,17 @@ declare type AuthIdentityProvider = {
   registration: {
     clientIdSettingName: string;
     clientSecretSettingName: string;
+    openIdIssuer?: string;
   };
 };
 
 declare type SWAConfigFileAuthIdenityProviders = {
-  github?: AuthIdentityProvider;
-  google?: AuthIdentityProvider;
+  [key: string]: AuthIdentityProvider;
 };
 
 declare type SWAConfigFileAuth = {
   rolesSource?: string;
-  identityProviders: SWAConfigFileAuthIdenityProviders;
+  identityProviders?: SWAConfigFileAuthIdenityProviders;
 };
 
 declare type SWAConfigFile = {

--- a/src/swa.d.ts
+++ b/src/swa.d.ts
@@ -290,6 +290,17 @@ declare type SWAConfigFileMimeTypes = {
   [key: string]: string;
 };
 
+declare type AuthIdentityTokenEndpoints = {
+  [key: string]: {
+    host: string;
+    path: string;
+  };
+};
+
+declare type AuthIdentityIssHosts = {
+  [key: string]: string;
+};
+
 declare type AuthIdentityProvider = {
   registration: {
     clientIdSettingName: string;


### PR DESCRIPTION
New feature: Adding AAD custom auth support using the previously created code for Google and GitHub. The previous code has been refactored and generalized for future auth providers to be added as well. Google and Github auth has also been regression tested successfully.

Tested in private environment with custom AAD application using the following staticwebapp.config.json:
![image](https://github.com/user-attachments/assets/3956d6e4-35af-4dec-be79-4de981dbab69)

Successful /.auth/me call with AAD credentials:
![image](https://github.com/user-attachments/assets/fd64bfd0-670a-47d9-be9a-fb0762b54943)

Successful /.auth/me call with Github credentials:
![image](https://github.com/user-attachments/assets/6df0d9e6-96f4-4300-869b-863eba860f8a)

Successful /.auth/me call with Google credentials:
![image](https://github.com/user-attachments/assets/8e7948d7-2a60-4a99-8f9f-c3b10a01c8d1)


