### PR TITLE
fix msha (#844): Regex for custom authentication providers

### DIFF
--- a/src/msha/auth/index.ts
+++ b/src/msha/auth/index.ts
@@ -36,7 +36,7 @@ function getAuthPaths(isCustomAuth: boolean): Path[] {
   } else {
     paths.push({
       method: "GET",
-      route: /^\/\.auth\/login\/(?<provider>github|twitter|google|facebook|[a-z]+)(\?.*)?$/i,
+      route: /^\/\.auth\/login\/(?<provider>github|twitter|google|facebook|[a-z0-9]+)(\?.*)?$/i,
       function: "auth-login-provider",
     });
   }
@@ -54,7 +54,7 @@ function getAuthPaths(isCustomAuth: boolean): Path[] {
     },
     {
       method: "GET",
-      route: /^\/\.auth\/purge\/(?<provider>aad|github|twitter|google|facebook|[a-z]+)(\?.*)?$/i,
+      route: /^\/\.auth\/purge\/(?<provider>aad|github|twitter|google|facebook|[a-z0-9]+)(\?.*)?$/i,
       // locally, all purge requests are processed as logout requests
       function: "auth-logout",
     },


### PR DESCRIPTION
Fixes #844: The regex ignores numbers in custom auth providers. Although various documented providers have numbers in their description (e.g. auth0, aadb2c). As a consequence they will not work with the local authorization emulator.

* [Doc example for aadb2c.](https://learn.microsoft.com/en-us/azure/active-directory-b2c/configure-authentication-in-azure-static-app#31-add-an-openid-connect-identity-provider)
* [Doc example for auth0](https://auth0.com/blog/support-auth0-in-azure-static-web-apps-for-blazor-wasm/)