### PR TITLE
fix: Update macos image in test workflows

### DIFF
--- a/.github/workflows/azuresdkdrop.yml
+++ b/.github/workflows/azuresdkdrop.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, windows-latest, ubuntu-latest]
+        os: [macos-14, windows-latest, ubuntu-latest]
         node-version: [18.x, 20.x]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12]
+        os: [macos-14]
         node-version: [18.x, 20.x]
 
     name: "test: use node ${{ matrix.node-version }}"
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12]
+        os: [macos-14]
         node-version: [18.x, 20.x]
 
     name: "deploy: use node ${{ matrix.node-version }}"


### PR DESCRIPTION
Fixes the maxOS-12 environment is deprecated error in this repo's testing workflows
![image](https://github.com/user-attachments/assets/8fc278f8-df95-4662-b783-0c671bb2e23a)

Testing: This PR's "ci" workflow should all pass