### PR TITLE
feature: Enable dotnet9 api runtime

### DIFF
--- a/schema/staticwebapp.config.json
+++ b/schema/staticwebapp.config.json
@@ -590,6 +590,7 @@
             "dotnet-isolated:6.0",
             "dotnet-isolated:7.0",
             "dotnet-isolated:8.0",
+            "dotnet-isolated:9.0",
             "node:12",
             "node:14",
             "node:16",


### PR DESCRIPTION
This PR adds the `dotnet-isolated:9.0` runtime in the staticwebapp.config.json allowing .NET9 apis to be deployed using the SWA CLI. 

Tested using private SWA CLI build with successful .NET9 deployment: 

![image](https://github.com/user-attachments/assets/5684f8b4-1892-4ba1-b897-55841cc7bdf8)

![image](https://github.com/user-attachments/assets/3991440a-1c61-4fc1-bc85-8d3c687312b1)


