### PR TITLE
fix: fix unit tests

### DIFF
--- a/.github/workflows/detection-e2e-tests.yml
+++ b/.github/workflows/detection-e2e-tests.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 14.x
+        node-version: 18.x
     - name: Test framework detection
       run: |
         npm ci

--- a/src/core/func-core-tools.spec.ts
+++ b/src/core/func-core-tools.spec.ts
@@ -147,7 +147,7 @@ describe("funcCoreTools", () => {
         },
       });
 
-      await expect(async () => await fct.getLatestCoreToolsRelease(4)).rejects.toThrowError("Cannot find the latest version for v4");
+      await expect(async () => await fct.getLatestCoreToolsRelease(4)).rejects.toThrowError("Error fetching Function Core Tools releases");
     });
 
     it("should throw an error if no release match the specified version", async () => {
@@ -158,7 +158,7 @@ describe("funcCoreTools", () => {
         releases: {},
       });
 
-      await expect(async () => await fct.getLatestCoreToolsRelease(4)).rejects.toThrowError("Cannot find release for 4.0.0");
+      await expect(async () => await fct.getLatestCoreToolsRelease(4)).rejects.toThrowError("Error fetching Function Core Tools releases");
     });
 
     it("should throw an error if there's no compatible package", async () => {


### PR DESCRIPTION
This PR fixes the unit tests for func-core-tools.spec.ts which contains new logic for a bug fix from PR #900 

Unit tests are now passing: 
![image](https://github.com/user-attachments/assets/fce887eb-fcfe-4cf7-9d50-5570e9c6fbcd)

e2e test in PR should also pass