### PR TITLE
fix: Fixed the inconsistency in the handling of AAD openIdIssuer

### DIFF
--- a/src/msha/auth/routes/auth-login-provider-custom.ts
+++ b/src/msha/auth/routes/auth-login-provider-custom.ts
@@ -87,7 +87,8 @@ const httpTrigger = async function (context: Context, request: IncomingMessage, 
       location = `https://github.com/login/oauth/authorize?response_type=code&client_id=${authFields?.clientIdSettingName}&redirect_uri=${redirectUri}/.auth/login/github/callback&scope=read:user&state=${hashedState}`;
       break;
     case "aad":
-      location = `${authFields?.openIdIssuer}/authorize?response_type=code&client_id=${authFields?.clientIdSettingName}&redirect_uri=${redirectUri}/.auth/login/aad/callback&scope=openid+profile+email&state=${hashedState}`;
+      const tenantId = authFields?.openIdIssuer.split("/")[3];
+      location = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/authorize?response_type=code&client_id=${authFields?.clientIdSettingName}&redirect_uri=${redirectUri}/.auth/login/aad/callback&scope=openid+profile+email&state=${hashedState}`;
       break;
     case "facebook":
       location = `https://facebook.com/v11.0/dialog/oauth?client_id=${authFields?.appIdSettingName}&redirect_uri=${redirectUri}/.auth/login/facebook/callback&scope=openid&state=${hashedState}&response_type=code`;


### PR DESCRIPTION
The value specified for `openIdIssuer` when using AAD was different from the value required by SWA, causing an inconsistency. This is fixed by constructing the URL based on the tenant ID.

Fixes #928