### PR TITLE
fix: Refactoring the download process for `StaticSiteClient`

### DIFF
--- a/src/core/download-binary-helper.ts
+++ b/src/core/download-binary-helper.ts
@@ -5,7 +5,6 @@ import stp from "node:stream/promises";
 import { fetchWithProxy as fetch } from "./utils/fetch-proxy.js";
 import ora from "ora";
 import path from "node:path";
-import { PassThrough } from "node:stream";
 import { DATA_API_BUILDER_BINARY_NAME, DATA_API_BUILDER_FOLDER, DEPLOY_BINARY_NAME, DEPLOY_FOLDER } from "./constants.js";
 import { logger } from "./utils/logger.js";
 
@@ -38,8 +37,6 @@ export async function downloadAndValidateBinary(
     throw new Error(`Failed to download ${binaryName} binary from url ${url}. File not found (${response.status})`);
   }
 
-  const bodyStream = response?.body?.pipe(new PassThrough());
-
   createBinaryDirectoryIfNotExists(id, outputFolder);
 
   const isPosix = platform === "linux-x64" || platform === "osx-x64";
@@ -47,7 +44,7 @@ export async function downloadAndValidateBinary(
 
   const writableStream = fs.createWriteStream(outputFile, { mode: isPosix ? 0o755 : undefined });
 
-  await stp.pipeline(bodyStream, writableStream);
+  await stp.pipeline(response.body, writableStream);
 
   const computedHash = computeChecksumfromFile(outputFile).toLowerCase();
   const releaseChecksum = releaseMetadata.files[platform].sha.toLowerCase();


### PR DESCRIPTION
Fixed an issue where `ETXTBSY` and `EBUSY` errors would occur when executing processes using `spawn` after the download process ran when `StaticSiteClient` did not exist.

In this PR, we simplified the close processing and error handling after downloading the file by using the Streams Promises API, and stabilized the download process.

I wrote the following workflow and checked the failure rate of the `swa deploy` command in the branches before and after the improvement.

```yaml
jobs:
  deploy:
    runs-on: windows-latest
    steps:
    - uses: actions/checkout@v4
    
    - uses: actions/checkout@v4
      with:
        repository: shibayan/static-web-apps-cli
        ref: deploy-client-download
        path: static-web-apps-cli

    - name: Build SWA CLI
      run: |
        npm install
        npm run build
      working-directory: ./static-web-apps-cli

    - name: Deploy to Static Web App
      run: node ./static-web-apps-cli/dist/cli/bin.js deploy ./dist/ --env production
```

`deploy-new.yml` is the workflow that uses the fixes in this PR. I can see that the deployment stability has improved significantly, as the failure rate of the workflow after the fixes is 0%, whereas the failure rate of the workflow before the fixes was over 60%.

![image](https://github.com/user-attachments/assets/533f80bb-5c92-4f7f-8e03-8c57a822d674)

![image](https://github.com/user-attachments/assets/61c15ca2-f856-4b14-92c7-16b7cdb774ea)

Fixes #721
Fixes #799
Fixes #916
