### PR TITLE
fix(msha): change auth regex for unsupported providers to allow providers with numbers

### DIFF
--- a/src/msha/auth/index.ts
+++ b/src/msha/auth/index.ts
@@ -25,7 +25,7 @@ function getAuthPaths(isCustomAuth: boolean): Path[] {
     paths.push({
       method: "GET",
       // For providers with custom auth support not implemented, revert to old behavior
-      route: /^\/\.auth\/login\/(?<provider>twitter|[a-z]+)(\?.*)?$/i,
+      route: /^\/\.auth\/login\/(?<provider>twitter|[a-z0-9]+)(\?.*)?$/i,
       function: "auth-login-provider",
     });
     paths.push({


### PR DESCRIPTION
Fix regression from #844 within the 2.x release and applies the same partial fix in #895 in the other code path.
This is to support providers such as Azure AD B2C or Auth0, which usually would be using 'aadb2c' or 'auth0'.