### PR TITLE
fix: correct duplicate 'init' property in schema to 'build'

### DIFF
--- a/schema/swa-cli.config.schema.json
+++ b/schema/swa-cli.config.schema.json
@@ -89,7 +89,7 @@
           },
           {
             "properties": {
-              "init": {
+              "build": {
                 "allOf": [
                   {
                     "$ref": "#/$defs/globalParameters"


### PR DESCRIPTION
## Summary
Fixes a bug in the JSON schema where a duplicate 'init' property should have been 'build'.

## Details
The schema file `/schema/swa-cli.config.schema.json` had a duplicate 'init' property at line 92 that was referencing `buildCommandParameters`. This property should have been named 'build' to match the parameters it references.

## Changes
- Changed line 92 from `"init": {` to `"build": {`

## Testing
- ✅ Validated JSON schema syntax
- ✅ All unit tests pass
- ✅ No breaking changes

## References
Fixes #705

Thanks to @javier-lopez-1s for reporting this issue\!