### PR TITLE
fix: handle Unicode characters in auth emulator usernames

### DIFF
--- a/src/public/auth.html
+++ b/src/public/auth.html
@@ -192,7 +192,9 @@
 
       function saveCookie(formElement) {
         const data = localStorage[hashStorageKey(formElement)];
-        document.cookie = `StaticWebAppsAuthCookie=${btoa(data)}; path=/`;
+        // Encode Unicode-safe by converting to UTF-8 first
+        const encoded = btoa(unescape(encodeURIComponent(data)));
+        document.cookie = `StaticWebAppsAuthCookie=${encoded}; path=/`;
       }
       function redirectToApp() {
         const defaultRedirectPath = "/";


### PR DESCRIPTION
## Summary
- Fixed issue where usernames containing Unicode characters (emojis, non-Latin text) would cause btoa() to throw an error
- Applied UTF-8 encoding before base64 encoding to properly handle Unicode characters

## Changes
- Updated `saveCookie()` function in `src/public/auth.html` to use `btoa(unescape(encodeURIComponent(data)))` instead of `btoa(data)`
- This ensures Unicode characters are properly encoded to UTF-8 before base64 encoding

## Test plan
- [x] Tested with various Unicode inputs including emojis (😊), Chinese characters (用户), and Arabic text (مستخدم)
- [x] Verified ASCII characters still work correctly
- [x] All existing unit tests pass

Fixes #269

🤖 Generated with [Claude Code](https://claude.ai/code)