### PR TITLE
fix: update AAD display name to Microsoft Entra ID in auth UI

### DIFF
--- a/src/public/auth.html
+++ b/src/public/auth.html
@@ -78,15 +78,15 @@
                     required="required"
                     class="form-control"
                   />
-                  <small id="identityProviderHelpBlock" class="form-text text-muted">Name of the identity provider</small>
+                  <small id="identityProviderHelpBlock" class="form-text text-muted">Name of the identity provider (aad = Microsoft Entra ID)</small>
                 </div>
                 <datalist id="providers-list">
-                  <option value="aad"></option>
-                  <option value="google"></option>
-                  <option value="github"></option>
-                  <option value="twitter"></option>
-                  <option value="facebook"></option>
-                  <option value="openid"></option>
+                  <option value="aad">Microsoft Entra ID</option>
+                  <option value="google">Google</option>
+                  <option value="github">GitHub</option>
+                  <option value="twitter">Twitter</option>
+                  <option value="facebook">Facebook</option>
+                  <option value="openid">OpenID</option>
                 </datalist>
               </div>
 


### PR DESCRIPTION
## Summary
- Updated the auth emulator UI to display "Microsoft Entra ID" instead of "AAD"
- Maintained backward compatibility by keeping 'aad' as the underlying provider value
- Added clarification in help text that "aad = Microsoft Entra ID"

## Changes
- Updated datalist options in `src/public/auth.html` to include display text for all providers
- Changed `<option value="aad"></option>` to `<option value="aad">Microsoft Entra ID</option>`
- Updated help text to clarify the mapping

## Test plan
- [x] Built the project successfully
- [x] All unit tests pass
- [x] The UI now shows "Microsoft Entra ID" in the dropdown while still using 'aad' as the value
- [x] No breaking changes - existing configurations and URLs continue to work

Fixes #850

🤖 Generated with [Claude Code](https://claude.ai/code)