### PR TITLE
feat: upgrade swa runtime version

### DIFF
--- a/schema/staticwebapp.config.json
+++ b/schema/staticwebapp.config.json
@@ -585,11 +585,19 @@
         "apiRuntime": {
           "type": "string",
           "enum": [
+            "dotnet:3.1",
+            "dotnet:6.0",
             "dotnet:8.0",
+            "dotnet-isolated:6.0",
+            "dotnet-isolated:7.0",
             "dotnet-isolated:8.0",
             "dotnet-isolated:9.0",
+            "node:12",
+            "node:14",
+            "node:16",
             "node:18",
             "node:20",
+            "python:3.8",
             "python:3.9",
             "python:3.10",
             "python:3.11"

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -305,10 +305,10 @@ export const DEFAULT_VERSION = {
 };
 
 export const SUPPORTED_VERSIONS = {
-  Node: ["18", "20"],
-  Dotnet: ["8.0"],
-  DotnetIsolated: ["8.0", "9.0"],
-  Python: ["3.9", "3.10", "3.11"],
+  Node: ["12", "14", "16", "18", "20"],
+  Dotnet: ["3.1", "6.0", "8.0"],
+  DotnetIsolated: ["6.0", "7.0", "8.0", "9.0"],
+  Python: ["3.8", "3.9", "3.10", "3.11"],
 };
 
 export const DEFAULT_RUNTIME_LANGUAGE = "node";


### PR DESCRIPTION
Newly added runtime:

dotnet 8 +v4 windows
python 3.11 +v4 Linux

These runtimes won't be supported in static site functions and are removed in the release.

dotnet 3.1 +v3 windows ---
dotnet 6 in process +v4 windows ---
dotnet 6 isolated +v4 windows ---
dotnet 7 isolated +v4 windows ---
node 12 +v3 Linux ---
node 14 +v4 Linux ---
node 16 +v4 Linux ---
python 3.8 +v3 Linux ---
python 3.8 +v4 Linux ---

Test in local env

To check what runtimes are supported please check this list: https://learn.microsoft.com/en-us/azure/static-web-apps/languages-runtimes