### PR TITLE
fix: update expired Yarn GPG key

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,6 +23,9 @@ RUN GROUPS=$(id -Gn vscode | sed "s/ /,/g" | sed -r 's/\<'vscode'\>\b,?//g') \
     && cp -r /home/vscode/. /home/$USERNAME \
     && chown -R swa-cli:vscode /home/$USERNAME
 
+# Update Yarn GPG key (the base image may have an expired key)
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarn-archive-keyring.gpg
+
 RUN bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}" \
     && apt-get update && apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb libsecret-1-0 \
     && if [ $CORE_TOOLS_VERSION != "4" ]; then apt-get remove -y azure-functions-core-tools-4 && apt-get install -y "azure-functions-core-tools-${CORE_TOOLS_VERSION}"; fi \


### PR DESCRIPTION
To fix issue: https://github.com/Azure/static-web-apps-cli/issues/982

Test result:

```
PS C:\wagit\static-web-apps-cli> docker build --no-cache -t swacli:test .devcontainer/
[+] Building 106.6s (12/12) FINISHED                                                                                               docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                               0.0s
 => => transferring dockerfile: 2.06kB                                                                                                             0.0s 
 => [internal] load metadata for mcr.microsoft.com/azure-functions/python:4-python3.9-core-tools                                                   0.6s 
 => [internal] load .dockerignore                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                    0.0s 
 => [internal] load build context                                                                                                                  0.0s 
 => => transferring context: 87B                                                                                                                   0.0s 
 => CACHED [1/7] FROM mcr.microsoft.com/azure-functions/python:4-python3.9-core-tools@sha256:a10adec4a30b670a8fa5dcfe5b3bd470a7f024700be4f14170a1  0.1s 
 => => resolve mcr.microsoft.com/azure-functions/python:4-python3.9-core-tools@sha256:a10adec4a30b670a8fa5dcfe5b3bd470a7f024700be4f14170a16155ca0  0.0s 
 => [2/7] COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/                                                                    0.1s
 => [3/7] RUN GROUPS=$(id -Gn vscode | sed "s/ /,/g" | sed -r 's/\<'vscode'\>\b,?//g')     && useradd --shell /bin/bash --groups ${GROUPS} --crea  1.1s 
 => [4/7] RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarn-archive-keyring.gpg                     0.8s
 => [5/7] RUN bash /tmp/library-scripts/node-debian.sh "/usr/local/share/nvm" "18" "swa-cli"     && apt-get update && apt-get install -y libgtk2  59.1s
 => [6/7] RUN su swa-cli -c "umask 0002 && npm install --cache /tmp/empty-cache -g npm@10 fuzz-run"     && if [ -n "$SWA_CLI_VERSION" ]; then su  16.7s
 => [7/7] WORKDIR /home/swa-cli                                                                                                                    0.1s
 => exporting to image                                                                                                                            27.4s
 => => exporting layers                                                                                                                           19.9s 
 => => exporting manifest sha256:5337b77f1dde8bc6fe4b6d6fd1133ef4403d6f1a9b0b9a9c4bfbae03e246fc94                                                  0.0s 
 => => exporting config sha256:a71ab824f43c75d9347ac06ab6bfb6125fdfcd5d21bf7200c98215b68e3ee7e3                                                    0.0s 
 => => exporting attestation manifest sha256:022652cbb93f3a1e70f67ca99d8332c29b191fb3f145025d6277ddb3d5e6643a                                      0.1s 
 => => exporting manifest list sha256:a679cc375ea4b271b9bdadc4f3f9d23456a78bb09f2745b8a701d1df40caadf2                                             0.0s 
 => => naming to docker.io/library/swacli:test                                                                                                     0.0s 
 => => unpacking to docker.io/library/swacli:test                                                                                                  7.3s 

PS C:\wagit\static-web-apps-cli> docker run --rm -it --user root swacli:test bash -c "apt-get update"
Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB]
Get:2 http://deb.debian.org/debian bookworm-updates InRelease [55.4 kB]
Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]                                                                       
Get:4 http://deb.debian.org/debian bookworm/main amd64 Packages [8792 kB]                                                                               
Get:5 https://dl.yarnpkg.com/debian stable InRelease                                                                                                    
Get:6 https://dl.yarnpkg.com/debian stable/main amd64 Packages [10.9 kB]                                                                                
Get:7 http://deb.debian.org/debian bookworm/main amd64 DEP-11 Metadata [4492 kB]                                                                        
Get:8 https://dl.yarnpkg.com/debian stable/main all Packages [10.9 kB]                                                                                  
Get:9 https://download.docker.com/linux/debian bookworm InRelease [46.6 kB]
Get:10 http://deb.debian.org/debian bookworm-updates/main amd64 Packages [6924 B]
Get:11 http://deb.debian.org/debian-security bookworm-security/main amd64 Packages [292 kB]
Get:12 https://download.docker.com/linux/debian bookworm/stable amd64 Packages [60.4 kB]
Get:13 https://packages.microsoft.com/repos/azure-cli bookworm InRelease [3576 B]
Get:14 https://packages.microsoft.com/repos/microsoft-debian-bookworm-prod bookworm InRelease [3618 B]
Get:15 https://packages.microsoft.com/debian/11/prod bullseye InRelease [3650 B]
Get:16 https://packages.microsoft.com/repos/azure-cli bookworm/main amd64 Packages [2712 B]
Get:17 https://packages.microsoft.com/repos/microsoft-debian-bookworm-prod bookworm/main amd64 Packages [150 kB]
Get:18 https://packages.microsoft.com/repos/microsoft-debian-bookworm-prod bookworm/main all Packages [573 B]
Get:19 https://packages.microsoft.com/debian/11/prod bullseye/main all Packages [1506 B]
Get:20 https://packages.microsoft.com/debian/11/prod bullseye/main armhf Packages [44.1 kB]
Get:21 https://packages.microsoft.com/debian/11/prod bullseye/main amd64 Packages [228 kB]
Get:22 https://packages.microsoft.com/debian/11/prod bullseye/main arm64 Packages [68.2 kB]
Fetched 14.5 MB in 6s (2606 kB/s)
Reading package lists... Done
W: https://download.docker.com/linux/debian/dists/bookworm/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
```