### PR TITLE
fix: use KB instead of bytes in config file size warning

### DIFF
--- a/src/core/utils/user-config.spec.ts
+++ b/src/core/utils/user-config.spec.ts
@@ -28,7 +28,7 @@ describe("userConfig", () => {
         {
           [convertToNativePaths(currentDir)]: {},
         },
-        currentDir
+        currentDir,
       );
       const entry = await asyncGeneratorToArray(traverseFolder("/"));
       expect(entry).toEqual([]);
@@ -129,7 +129,7 @@ describe("userConfig", () => {
         {
           [convertToNativePaths(currentDir)]: {},
         },
-        currentDir
+        currentDir,
       );
       const file = await findSWAConfigFile("/");
       expect(file).toBe(null);
@@ -159,7 +159,7 @@ describe("userConfig", () => {
       expect(config).toBeNull();
       expect(logger.warn).toHaveBeenLastCalledWith(
         `   WARNING: Functionality defined in the routes.json file is now deprecated. File will be ignored!\n` +
-          `   Read more: https://docs.microsoft.com/azure/static-web-apps/configuration#routes`
+          `   Read more: https://docs.microsoft.com/azure/static-web-apps/configuration#routes`,
       );
     });
 
@@ -178,8 +178,27 @@ describe("userConfig", () => {
       expect(config).toBeNull();
       expect(logger.warn).toHaveBeenLastCalledWith(
         `   WARNING: Functionality defined in the routes.json file is now deprecated. File will be ignored!\n` +
-          `   Read more: https://docs.microsoft.com/azure/static-web-apps/configuration#routes`
+          `   Read more: https://docs.microsoft.com/azure/static-web-apps/configuration#routes`,
       );
+    });
+
+    it("should warn with KB unit when config file exceeds max size", async () => {
+      // Create a valid config file larger than 20KB (SWA_RUNTIME_CONFIG_MAX_SIZE_IN_KB)
+      // Use many routes to inflate file size while keeping schema valid
+      const routes = [];
+      for (let i = 0; i < 500; i++) {
+        routes.push({ route: `/route-${i}-${"a".repeat(30)}`, rewrite: `/index-${i}.html` });
+      }
+      const largeContent = JSON.stringify({ routes });
+      vol.fromJSON({
+        "staticwebapp.config.json": largeContent,
+      });
+
+      vi.spyOn(logger, "log").mockImplementation(() => {});
+
+      await findSWAConfigFile("/");
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("KB"));
+      expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("bytes"));
     });
 
     it("should ignore routes.json if a staticwebapp.config.json exists", async () => {

--- a/src/core/utils/user-config.ts
+++ b/src/core/utils/user-config.ts
@@ -62,7 +62,7 @@ export async function findSWAConfigFile(folder: string): Promise<{ filepath: str
           const fileSize = (await fs.stat(file.filepath)).size;
           const fileSizeInKb = Math.round(fileSize / 1024);
           if (fileSizeInKb > SWA_RUNTIME_CONFIG_MAX_SIZE_IN_KB) {
-            logger.warn(`WARNING: ${SWA_CONFIG_FILENAME} is ${fileSizeInKb} bytes. The maximum size is ${SWA_RUNTIME_CONFIG_MAX_SIZE_IN_KB} bytes.`);
+            logger.warn(`WARNING: ${SWA_CONFIG_FILENAME} is ${fileSizeInKb} KB. The maximum size is ${SWA_RUNTIME_CONFIG_MAX_SIZE_IN_KB} KB.`);
           }
 
           logger.silly(`Content parsed successfully`);
@@ -85,7 +85,7 @@ export async function findSWAConfigFile(folder: string): Promise<{ filepath: str
     logger.warn(`Found legacy configuration file: ${file?.filepath}.`);
     logger.warn(
       `   WARNING: Functionality defined in the routes.json file is now deprecated. File will be ignored!\n` +
-        `   Read more: https://docs.microsoft.com/azure/static-web-apps/configuration#routes`
+        `   Read more: https://docs.microsoft.com/azure/static-web-apps/configuration#routes`,
     );
     return null;
   }


### PR DESCRIPTION
Fixes #973

## Problem

When `staticwebapp.config.json` exceeds the maximum allowed size (20 KB), the warning message incorrectly displays the unit as "bytes" instead of "KB":

```
WARNING: staticwebapp.config.json is 22 bytes. The maximum size is 20 bytes.
```

The values shown (22, 20) are already in kilobytes (the variable is `fileSizeInKb` and the constant is `SWA_RUNTIME_CONFIG_MAX_SIZE_IN_KB`), but the label says "bytes".

## Fix

Changed the warning message in `src/core/utils/user-config.ts` to use "KB" instead of "bytes":

```
WARNING: staticwebapp.config.json is 22 KB. The maximum size is 20 KB.
```

## Testing

Added a test case in `src/core/utils/user-config.spec.ts` that verifies:
- The warning message contains "KB"
- The warning message does not contain "bytes"

All existing tests continue to pass.