### PR TITLE
chore: align DATA_API_BUILDER_VERSION_ID with manifest latest (#969)

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -24,7 +24,7 @@ export const DATA_API_BUILDER_DEFAULT_CONFIG_FILE_NAME = "staticwebapp.database.
 export const DATA_API_BUILDER_DEFAULT_SCHEMA_FILE_NAME = "staticwebapp.database.schema.gql";
 export const DATA_API_BUILDER_DEFAULT_FOLDER = "swa-db-connections";
 export const DATA_API_BUILDER_DEFAULT_REST_PATH = "/rest";
-export const DATA_API_BUILDER_VERSION_ID = "0.5.32";
+export const DATA_API_BUILDER_VERSION_ID = "1.3.19";
 export const DEFAULT_DATA_API_BUILDER_BINARY = {
   Windows: "Microsoft.DataApiBuilder.exe",
   Linux: "Microsoft.DataApiBuilder",


### PR DESCRIPTION
## Problem

Issue #969 reports that `DATA_API_BUILDER_VERSION_ID` in [`src/core/constants.ts`](https://github.com/Azure/static-web-apps-cli/blob/main/src/core/constants.ts#L27) was pinned to `0.5.32`, while the upstream [DAB release-metadata manifest](https://go.microsoft.com/fwlink/?linkid=2226493) has since advanced well beyond that value. The mismatch is misleading for contributors reading the source — the manifest already serves a newer `latest`, but the constant suggests the CLI is still on the legacy 0.5.x line.

Verified live manifest state (2026-04-21):

```json
{
  "version": "latest",
  "versionId": "1.3.19",
  "releaseType": "released",
  "releaseDate": "2024-11-29"
}
```

## Root Cause

The constant is a static pin that has not been updated alongside DAB releases. It is referenced only by a commented-out line in `src/core/dataApiBuilder/dab.ts` intended for optional version pinning — runtime behavior is driven by the manifest's `latest` entry, not by this constant. So the value has drifted without functional impact.

## Fix

| File | Change |
|---|---|
| `src/core/constants.ts` | `DATA_API_BUILDER_VERSION_ID` `0.5.32` → `1.3.19` |

`1.3.19` matches the `latest` entry currently served by the DAB fwlink manifest. A subsequent bump to 1.5.x / 1.7.x can be done once the DAB team promotes a newer build to `latest` in the manifest (the issue author also suggests coordinating with the DAB team for timely updates).

## Testing

- ✅ `git diff` shows single-line change in constants.
- ✅ No code references `DATA_API_BUILDER_VERSION_ID` at runtime (grep confirms only a commented-out usage in `dab.ts`); no behavior change.
- ✅ Value matches live manifest `latest.versionId`.

## References

- Fixes #969
