### PR TITLE
fix: allow clientSecretCertificateKeyVaultReference in AAD auth schema (#944)

### DIFF
--- a/schema/staticwebapp.config.json
+++ b/schema/staticwebapp.config.json
@@ -81,7 +81,7 @@
                 },
                 "registration": {
                   "type": "object",
-                  "required": ["openIdIssuer", "clientSecretSettingName"],
+                  "required": ["openIdIssuer"],
                   "properties": {
                     "openIdIssuer": {
                       "type": "string",
@@ -93,9 +93,17 @@
                     },
                     "clientSecretSettingName": {
                       "type": "string",
-                      "description": "The name of the application setting containing the client secret for the Azure AD app registration"
+                      "description": "The name of the application setting containing the client secret for the Azure AD app registration. Mutually exclusive with clientSecretCertificateKeyVaultReference."
+                    },
+                    "clientSecretCertificateKeyVaultReference": {
+                      "type": "string",
+                      "description": "A Key Vault reference to a certificate used as the client credential for the Azure AD app registration. Use this instead of clientSecretSettingName when authenticating with a certificate stored in Key Vault. See https://aka.ms/swa-authentication-custom"
                     }
                   },
+                  "oneOf": [
+                    { "required": ["clientSecretSettingName"] },
+                    { "required": ["clientSecretCertificateKeyVaultReference"] }
+                  ],
                   "additionalProperties": false
                 },
                 "login": {


### PR DESCRIPTION
## Problem

Issue #944: `swa deploy` rejects the documented cert-based AAD custom-auth configuration with a schema validation error. The shape is published on Microsoft Learn ([Custom authentication in Azure Static Web Apps](https://learn.microsoft.com/azure/static-web-apps/authentication-custom?tabs=aad%2Cinvitations)) and uses `clientSecretCertificateKeyVaultReference`, but the CLI's `staticwebapp.config.json` schema does not allow it.

## Root Cause

In [`schema/staticwebapp.config.json`](https://github.com/Azure/static-web-apps-cli/blob/main/schema/staticwebapp.config.json#L82) the `azureActiveDirectory.registration` object:

1. Declares `clientSecretSettingName` as unconditionally `required`.
2. Does not define `clientSecretCertificateKeyVaultReference` as an allowed property, so `additionalProperties: false` rejects it.

Both conditions together make the cert-based shape invalid. Maintainer [@Timothyw0](https://github.com/Timothyw0) confirmed on the issue that this exact file + line is where the change belongs.

## Fix

| File | Change |
|---|---|
| `schema/staticwebapp.config.json` | Add `clientSecretCertificateKeyVaultReference` property; relax `required` to `["openIdIssuer"]`; add `oneOf` that requires **exactly one** of `clientSecretSettingName` or `clientSecretCertificateKeyVaultReference`. |

The `oneOf` preserves the original intent — a credential must still be configured — while permitting either credential shape. `additionalProperties: false` is kept so unknown keys still fail validation.

## Testing

- ✅ Existing shape with `clientSecretSettingName` still validates (covered by `oneOf` branch 1).
- ✅ New shape with `clientSecretCertificateKeyVaultReference` now validates (covered by `oneOf` branch 2).
- ✅ Missing both credentials fails validation (oneOf requires exactly one).
- ✅ Providing both credentials fails validation (oneOf rejects matches on both branches) — this is desirable because they are mutually exclusive at the platform level.
- ✅ Existing description text preserved; only the `clientSecretSettingName` description was extended to clarify mutual exclusion.

## References

- Fixes #944
- Docs: [Custom authentication in Azure Static Web Apps](https://learn.microsoft.com/azure/static-web-apps/authentication-custom?tabs=aad%2Cinvitations)
- Guidance comment: https://github.com/Azure/static-web-apps-cli/issues/944\#issuecomment pointer from @Timothyw0