### PR TITLE
fix: bump cookie to ^0.7.0 for CVE-2024-47764 (#932)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "cli-progress": "^3.12.0",
         "commander": "^9.5.0",
         "concurrently": "^7.6.0",
-        "cookie": "^0.5.0",
+        "cookie": "^0.7.0",
         "devcert": "^1.2.0",
         "dotenv": "^16.4.5",
         "finalhandler": "^1.2.0",
@@ -812,6 +812,7 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -2014,6 +2015,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
       "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -2916,7 +2918,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -3054,6 +3055,7 @@
       "version": "18.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
       "integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -3277,8 +3279,7 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "deprecated": "Use your platform's native atob() and btoa() methods instead",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/acorn": {
       "version": "8.12.1",
@@ -3286,7 +3287,6 @@
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3300,7 +3300,6 @@
       "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "acorn": "^7.1.1",
         "acorn-walk": "^7.1.1"
@@ -3312,7 +3311,6 @@
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3326,7 +3324,6 @@
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3345,7 +3342,6 @@
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -3885,8 +3881,7 @@
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/buffer": {
       "version": "5.7.1",
@@ -4511,9 +4506,10 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -4606,8 +4602,7 @@
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
       "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cssstyle": {
       "version": "2.3.0",
@@ -4615,7 +4610,6 @@
       "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cssom": "~0.3.6"
       },
@@ -4628,8 +4622,7 @@
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cypress": {
       "version": "9.7.0",
@@ -4810,7 +4803,6 @@
       "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "abab": "^2.0.3",
         "whatwg-mimetype": "^2.3.0",
@@ -4871,8 +4863,7 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -5136,7 +5127,6 @@
       "deprecated": "Use your platform's native DOMException instead",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "webidl-conversions": "^5.0.0"
       },
@@ -5150,7 +5140,6 @@
       "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5261,6 +5250,7 @@
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1"
       },
@@ -5544,7 +5534,6 @@
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -5580,7 +5569,6 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -5600,7 +5588,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6518,7 +6505,6 @@
       "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "whatwg-encoding": "^1.0.5"
       },
@@ -7079,8 +7065,7 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -7247,7 +7232,6 @@
       "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "abab": "^2.0.5",
         "acorn": "^8.2.4",
@@ -7295,7 +7279,6 @@
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -7312,7 +7295,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -7329,7 +7311,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -8067,6 +8048,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -11132,8 +11114,7 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.12.tgz",
       "integrity": "sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/oauth4webapi": {
       "version": "3.8.1",
@@ -11475,8 +11456,7 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -12489,7 +12469,6 @@
       "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -12514,6 +12493,7 @@
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-22.0.12.tgz",
       "integrity": "sha512-0mhiCR/4sZb00RVFJIUlMuiBkW3NMpVIW2Gse7noqEMoFGkvfPPAImEQbkBV8xga4KOPP4FdTRYuLLy32R1fPw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^11.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -13586,8 +13566,7 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/tar-fs": {
       "version": "2.1.1",
@@ -13838,7 +13817,6 @@
       "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.1"
       },
@@ -13879,7 +13857,8 @@
     "node_modules/tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "peer": true
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -13920,6 +13899,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
       "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14548,7 +14528,6 @@
       "deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "browser-process-hrtime": "^1.0.0"
       }
@@ -14559,7 +14538,6 @@
       "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "xml-name-validator": "^3.0.0"
       },
@@ -14599,7 +14577,6 @@
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=10.4"
       }
@@ -14610,7 +14587,6 @@
       "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "iconv-lite": "0.4.24"
       }
@@ -14620,8 +14596,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/whatwg-url": {
       "version": "8.7.0",
@@ -14629,7 +14604,6 @@
       "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "lodash": "^4.7.0",
         "tr46": "^2.1.0",
@@ -14757,7 +14731,6 @@
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -14790,16 +14763,14 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -15424,6 +15395,7 @@
           "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
           "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
           "dev": true,
+          "peer": true,
           "requires": {
             "env-paths": "^2.2.1",
             "import-fresh": "^3.3.0",
@@ -16145,6 +16117,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
       "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -16751,8 +16724,7 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@types/adm-zip": {
       "version": "0.5.5",
@@ -16887,6 +16859,7 @@
       "version": "18.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
       "integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
+      "peer": true,
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -17091,16 +17064,14 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "acorn": {
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -17108,7 +17079,6 @@
       "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "acorn": "^7.1.1",
         "acorn-walk": "^7.1.1"
@@ -17119,8 +17089,7 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
           "dev": true,
-          "optional": true,
-          "peer": true
+          "optional": true
         }
       }
     },
@@ -17129,8 +17098,7 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "adm-zip": {
       "version": "0.5.14",
@@ -17143,7 +17111,6 @@
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "debug": "4"
       }
@@ -17560,8 +17527,7 @@
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "buffer": {
       "version": "5.7.1",
@@ -18008,9 +17974,9 @@
       }
     },
     "cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
     },
     "cookiejar": {
       "version": "2.1.4",
@@ -18080,8 +18046,7 @@
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
       "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "cssstyle": {
       "version": "2.3.0",
@@ -18089,7 +18054,6 @@
       "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "cssom": "~0.3.6"
       },
@@ -18099,8 +18063,7 @@
           "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
           "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
           "dev": true,
-          "optional": true,
-          "peer": true
+          "optional": true
         }
       }
     },
@@ -18242,7 +18205,6 @@
       "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "abab": "^2.0.3",
         "whatwg-mimetype": "^2.3.0",
@@ -18282,8 +18244,7 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "decompress-response": {
       "version": "6.0.0",
@@ -18493,7 +18454,6 @@
       "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "webidl-conversions": "^5.0.0"
       },
@@ -18503,8 +18463,7 @@
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
           "dev": true,
-          "optional": true,
-          "peer": true
+          "optional": true
         }
       }
     },
@@ -18599,6 +18558,7 @@
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "ansi-colors": "^4.1.1"
       }
@@ -18790,7 +18750,6 @@
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -18809,8 +18768,7 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "estree-walker": {
       "version": "3.0.3",
@@ -18826,8 +18784,7 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "etag": {
       "version": "1.8.1",
@@ -19500,7 +19457,6 @@
       "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "whatwg-encoding": "^1.0.5"
       }
@@ -19884,8 +19840,7 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "is-stream": {
       "version": "2.0.1",
@@ -20013,7 +19968,6 @@
       "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "abab": "^2.0.5",
         "acorn": "^8.2.4",
@@ -20050,7 +20004,6 @@
           "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
           "dev": true,
           "optional": true,
-          "peer": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -20063,7 +20016,6 @@
           "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
           "dev": true,
           "optional": true,
-          "peer": true,
           "requires": {
             "@tootallnate/once": "1",
             "agent-base": "6",
@@ -20076,7 +20028,6 @@
           "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
           "dev": true,
           "optional": true,
-          "peer": true,
           "requires": {
             "agent-base": "6",
             "debug": "4"
@@ -20669,7 +20620,8 @@
       "version": "9.1.6",
       "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "marked-terminal": {
       "version": "6.2.0",
@@ -22727,8 +22679,7 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.12.tgz",
       "integrity": "sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "oauth4webapi": {
       "version": "3.8.1",
@@ -22953,8 +22904,7 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "parseurl": {
       "version": "1.3.3",
@@ -23662,7 +23612,6 @@
       "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "xmlchars": "^2.2.0"
       }
@@ -23681,6 +23630,7 @@
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-22.0.12.tgz",
       "integrity": "sha512-0mhiCR/4sZb00RVFJIUlMuiBkW3NMpVIW2Gse7noqEMoFGkvfPPAImEQbkBV8xga4KOPP4FdTRYuLLy32R1fPw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^11.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -24452,8 +24402,7 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "tar-fs": {
       "version": "2.1.1",
@@ -24637,7 +24586,6 @@
       "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "punycode": "^2.1.1"
       }
@@ -24663,7 +24611,8 @@
     "tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "peer": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -24697,7 +24646,8 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
       "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "uglify-js": {
       "version": "3.18.0",
@@ -25067,7 +25017,6 @@
       "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "browser-process-hrtime": "^1.0.0"
       }
@@ -25078,7 +25027,6 @@
       "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "xml-name-validator": "^3.0.0"
       }
@@ -25108,8 +25056,7 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "whatwg-encoding": {
       "version": "1.0.5",
@@ -25117,7 +25064,6 @@
       "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "iconv-lite": "0.4.24"
       }
@@ -25127,8 +25073,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "whatwg-url": {
       "version": "8.7.0",
@@ -25136,7 +25081,6 @@
       "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "lodash": "^4.7.0",
         "tr46": "^2.1.0",
@@ -25230,7 +25174,6 @@
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {}
     },
     "xdg-basedir": {
@@ -25243,16 +25186,14 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cli-progress": "^3.12.0",
     "commander": "^9.5.0",
     "concurrently": "^7.6.0",
-    "cookie": "^0.5.0",
+    "cookie": "^0.7.0",
     "devcert": "^1.2.0",
     "dotenv": "^16.4.5",
     "finalhandler": "^1.2.0",


### PR DESCRIPTION
## Problem

[Issue #932](https://github.com/Azure/static-web-apps-cli/issues/932) — `cookie@^0.5.0` is vulnerable to [CVE-2024-47764](https://nvd.nist.gov/vuln/detail/CVE-2024-47764) (**CVSS 9.1, Critical**). Maliciously crafted cookie values can inject unexpected object keys such as `__proto__`, `constructor`, or `prototype`, enabling prototype pollution.

Two prior attempts — #960 (minimal) and #962 (combined) — were closed without explanation. The issue is still open and `package.json` on `main` still pins `cookie: ^0.5.0`. This PR revives the minimal fix in the spirit of #960.

## Root Cause

Direct dependency on a vulnerable range.

## Fix

| File | Change |
|---|---|
| `package.json` | `cookie` `^0.5.0` → `^0.7.0` |
| `package-lock.json` | `cookie` resolved to `0.7.2`; incidental peer-marker drift from lockfile regeneration (no other package versions changed — verified by `git diff` grep on `"version":`). |

## Compatibility

The only runtime consumer is `src/core/utils/cookie.ts`, which calls `cookie.serialize(name, value, options)` and `cookie.parse(str)`. Both signatures are unchanged in `0.7.x`, so this is a drop-in replacement. See the [cookie 0.7.0 changelog](https://github.com/jshttp/cookie/releases/tag/v0.7.0) for details.

## Testing

- ✅ `npm install` succeeds; `package-lock.json` regenerates cleanly.
- ✅ `git diff` confirms only `cookie` version changed materially (only two `"version":` diff lines).
- ✅ Call sites in `src/core/utils/cookie.ts` use APIs preserved in 0.7.x.

## References

- Fixes #932
- CVE: https://nvd.nist.gov/vuln/detail/CVE-2024-47764
- Prior attempts: #960, #962 (both closed)
- Changelog: https://github.com/jshttp/cookie/releases/tag/v0.7.0