### PR TITLE
fix(auth): restore AAD local emulator fallback and normalize openIdIssuer URL (#947)

### DIFF
--- a/src/core/utils/openidHelper.spec.ts
+++ b/src/core/utils/openidHelper.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { normalizeOpenIdIssuer } from "./openidHelper.js";
+
+describe("normalizeOpenIdIssuer", () => {
+  describe("Microsoft identity platform (login.microsoftonline.com)", () => {
+    it("strips legacy /oauth2 segment for v2.0 issuer so discovery resolves (fixes ERR_TOO_MANY_REDIRECTS)", () => {
+      // Deployed SWA runtime accepts `.../<tenant>/v2.0` but the local CLI's
+      // `openid-client.discovery()` requires the canonical issuer (no /oauth2).
+      // Users must be able to use the same `staticwebapp.config.json` in both
+      // environments, so the CLI normalizes the legacy form before discovery.
+      const input = "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0";
+      const expected = "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0";
+      expect(normalizeOpenIdIssuer(input)).toBe(expected);
+    });
+
+    it("preserves the canonical v2.0 issuer unchanged", () => {
+      const input = "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0";
+      expect(normalizeOpenIdIssuer(input)).toBe(input);
+    });
+
+    it("preserves the issuer regardless of a trailing slash", () => {
+      const input = "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0/";
+      expect(normalizeOpenIdIssuer(input)).toBe(input);
+    });
+
+    it("handles common-tenant (multi-tenant) endpoint with /oauth2/ prefix", () => {
+      const input = "https://login.microsoftonline.com/common/oauth2/v2.0";
+      expect(normalizeOpenIdIssuer(input)).toBe("https://login.microsoftonline.com/common/v2.0");
+    });
+
+    it("handles organizations-tenant endpoint with /oauth2/ prefix", () => {
+      const input = "https://login.microsoftonline.com/organizations/oauth2/v2.0";
+      expect(normalizeOpenIdIssuer(input)).toBe("https://login.microsoftonline.com/organizations/v2.0");
+    });
+  });
+
+  describe("Entra External ID (ciamlogin.com)", () => {
+    it("preserves ciamlogin.com issuer unchanged (already canonical)", () => {
+      const input = "https://contoso.ciamlogin.com/contoso.onmicrosoft.com/v2.0";
+      expect(normalizeOpenIdIssuer(input)).toBe(input);
+    });
+
+    it("strips legacy /oauth2 segment from ciamlogin.com issuer when present", () => {
+      const input = "https://contoso.ciamlogin.com/contoso.onmicrosoft.com/oauth2/v2.0";
+      expect(normalizeOpenIdIssuer(input)).toBe("https://contoso.ciamlogin.com/contoso.onmicrosoft.com/v2.0");
+    });
+  });
+
+  describe("Entra custom URL domains", () => {
+    it("preserves custom-domain issuer unchanged", () => {
+      const input = "https://login.contoso.com/00000000-0000-0000-0000-000000000000/v2.0";
+      expect(normalizeOpenIdIssuer(input)).toBe(input);
+    });
+
+    it("strips legacy /oauth2 segment from custom-domain issuer when present", () => {
+      const input = "https://login.contoso.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0";
+      expect(normalizeOpenIdIssuer(input)).toBe("https://login.contoso.com/00000000-0000-0000-0000-000000000000/v2.0");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns an empty string unchanged (upstream validates separately)", () => {
+      expect(normalizeOpenIdIssuer("")).toBe("");
+    });
+
+    it("returns a non-matching URL unchanged", () => {
+      const input = "https://example.com/some/other/issuer";
+      expect(normalizeOpenIdIssuer(input)).toBe(input);
+    });
+
+    it("does not strip /oauth2 when it is not followed by /v2.0", () => {
+      // Defensive: we only target the known Microsoft legacy alias form.
+      const input = "https://example.com/tenant/oauth2/other";
+      expect(normalizeOpenIdIssuer(input)).toBe(input);
+    });
+  });
+});

--- a/src/core/utils/openidHelper.ts
+++ b/src/core/utils/openidHelper.ts
@@ -1,5 +1,33 @@
 import * as client from "openid-client";
 
+/**
+ * Normalize an `openIdIssuer` URL so that `openid-client`'s discovery
+ * (`<issuer>/.well-known/openid-configuration`) resolves in both local CLI
+ * and deployed SWA environments.
+ *
+ * Background: the Microsoft identity platform v2.0 canonical issuer is
+ * `https://login.microsoftonline.com/<tenant>/v2.0`. A legacy/alias form,
+ * `https://login.microsoftonline.com/<tenant>/oauth2/v2.0`, is accepted by
+ * the deployed SWA runtime but causes the CLI's OIDC discovery to fail
+ * (ERR_TOO_MANY_REDIRECTS or 404). We strip the trailing `/oauth2` segment
+ * so that users can keep a single `staticwebapp.config.json` that works
+ * both locally and when deployed.
+ *
+ * The same normalization applies to Entra External ID (`*.ciamlogin.com`)
+ * and Entra custom URL domains — any `.../<tenant>/oauth2/v2.0` suffix is
+ * rewritten to `.../<tenant>/v2.0`.
+ *
+ * See: https://github.com/Azure/static-web-apps-cli/issues/947
+ */
+export function normalizeOpenIdIssuer(issuer: string): string {
+  if (!issuer) {
+    return issuer;
+  }
+  // Rewrite `/oauth2/v2.0` (with optional trailing slash) to `/v2.0` while
+  // preserving any trailing slash the user provided.
+  return issuer.replace(/\/oauth2\/v2\.0(\/?)$/, "/v2.0$1");
+}
+
 export class OpenIdHelper {
   private issuerUrl: URL;
   private clientId: string;
@@ -11,7 +39,7 @@ export class OpenIdHelper {
     if (!clientId || clientId.trim() === "") {
       throw new Error("Client ID is required");
     }
-    this.issuerUrl = new URL(issuerUrl);
+    this.issuerUrl = new URL(normalizeOpenIdIssuer(issuerUrl));
     this.clientId = clientId;
   }
 

--- a/src/msha/auth/routes/auth-login-provider-custom.spec.ts
+++ b/src/msha/auth/routes/auth-login-provider-custom.spec.ts
@@ -1,0 +1,127 @@
+// Tests that `/.auth/login/aad` in local dev — when the real AAD env vars are
+// NOT set — falls back to the SWA local auth emulator instead of returning
+// `AAD_CLIENT_ID not found in env for 'aad' provider`.
+//
+// Regression coverage for https://github.com/Azure/static-web-apps-cli/issues/947
+// which was broken in 2.0.3 by PR #905.
+
+vi.mock("../../../core/constants", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../core/constants.js")>();
+  return {
+    ...actual,
+    SWA_CLI_APP_PROTOCOL: "http",
+  };
+});
+
+// Mock the auth-login-provider module so we can assert emulator delegation
+// without depending on the real HTML fixture file.
+vi.mock("./auth-login-provider.js", () => {
+  return {
+    default: vi.fn(async (context: Context, _request: unknown) => {
+      context.res = {
+        status: 200,
+        headers: { "Content-Type": "text/html" },
+        body: "<emulator></emulator>",
+      };
+    }),
+  };
+});
+
+import { IncomingMessage } from "node:http";
+import authLoginProviderEmulator from "./auth-login-provider.js";
+import httpTrigger from "./auth-login-provider-custom.js";
+
+describe("auth-login-provider-custom — AAD local emulator fallback (issue #947)", () => {
+  let context: Context;
+  let req: IncomingMessage;
+
+  const baseCustomAuth = {
+    identityProviders: {
+      azureActiveDirectory: {
+        registration: {
+          openIdIssuer: "https://login.microsoftonline.com/tenant-id/v2.0",
+          clientIdSettingName: "AAD_CLIENT_ID",
+          clientSecretSettingName: "AAD_CLIENT_SECRET",
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    context = { bindingData: { provider: "aad" } } as unknown as Context;
+    req = {
+      url: "/.auth/login/aad",
+      headers: { host: "localhost:4280" },
+    } as IncomingMessage;
+    delete process.env.AAD_CLIENT_ID;
+    delete process.env.AAD_CLIENT_SECRET;
+    vi.mocked(authLoginProviderEmulator).mockClear();
+  });
+
+  it("falls back to the local auth emulator when AAD clientId env var is unset", async () => {
+    // Only secret is set — clientId is missing.
+    process.env.AAD_CLIENT_SECRET = "test-secret";
+
+    await httpTrigger(context, req, baseCustomAuth);
+
+    expect(authLoginProviderEmulator).toHaveBeenCalledOnce();
+    // The custom handler should NOT have returned the 400 error from 2.0.3+.
+    expect(context.res.status).not.toBe(400);
+  });
+
+  it("falls back to the local auth emulator when AAD clientSecret env var is unset", async () => {
+    // Only clientId is set — secret is missing.
+    process.env.AAD_CLIENT_ID = "test-client-id";
+
+    await httpTrigger(context, req, baseCustomAuth);
+
+    expect(authLoginProviderEmulator).toHaveBeenCalledOnce();
+    expect(context.res.status).not.toBe(400);
+  });
+
+  it("falls back when both AAD env vars are unset (common local-dev case)", async () => {
+    await httpTrigger(context, req, baseCustomAuth);
+
+    expect(authLoginProviderEmulator).toHaveBeenCalledOnce();
+    // Before the fix, this would have been: 400 with body
+    // "AAD_CLIENT_ID not found in env for 'aad' provider".
+    expect(context.res.status).not.toBe(400);
+  });
+
+  it("does NOT fall back when both AAD env vars are set (real-auth path)", async () => {
+    process.env.AAD_CLIENT_ID = "test-client-id";
+    process.env.AAD_CLIENT_SECRET = "test-secret";
+
+    // We don't care about discovery here — either a 302 to the issuer or a
+    // discovery error is fine; we only assert we did NOT delegate to the
+    // emulator.
+    try {
+      await httpTrigger(context, req, baseCustomAuth);
+    } catch {
+      // discovery may fail against the fake tenant — that's OK for this assertion.
+    }
+
+    expect(authLoginProviderEmulator).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fall back when the config itself is missing a required field (hard error)", async () => {
+    // Missing `clientIdSettingName` entirely — this is a user config bug, not
+    // a local-dev signal, so the handler should surface a 400 as before.
+    const brokenAuth = {
+      identityProviders: {
+        azureActiveDirectory: {
+          registration: {
+            openIdIssuer: "https://login.microsoftonline.com/tenant-id/v2.0",
+            clientSecretSettingName: "AAD_CLIENT_SECRET",
+          },
+        },
+      },
+    };
+    process.env.AAD_CLIENT_SECRET = "test-secret";
+
+    await httpTrigger(context, req, brokenAuth as unknown as SWAConfigFileAuth);
+
+    expect(authLoginProviderEmulator).not.toHaveBeenCalled();
+    expect(context.res.status).toBe(400);
+  });
+});

--- a/src/msha/auth/routes/auth-login-provider-custom.ts
+++ b/src/msha/auth/routes/auth-login-provider-custom.ts
@@ -5,12 +5,45 @@ import { CUSTOM_AUTH_REQUIRED_FIELDS, ENTRAID_FULL_NAME, SWA_CLI_APP_PROTOCOL } 
 import { DEFAULT_CONFIG } from "../../../config.js";
 import { encryptAndSign, extractPostLoginRedirectUri, hashStateGuid, newNonceWithExpiration } from "../../../core/utils/auth.js";
 import { OpenIdHelper } from "../../../core/utils/openidHelper.js";
+import { logger } from "../../../core/utils/logger.js";
+import authLoginProviderEmulator from "./auth-login-provider.js";
 
 export const normalizeAuthProvider = function (providerName?: string) {
   if (providerName === ENTRAID_FULL_NAME) {
     return "aad";
   }
   return providerName?.toLowerCase() || "";
+};
+
+/**
+ * For the `aad` custom auth provider, when the user's `staticwebapp.config.json`
+ * references AAD env vars (clientIdSettingName / clientSecretSettingName) but
+ * those env vars are NOT set, we fall back to the SWA local auth emulator
+ * instead of hard-failing with a 400.
+ *
+ * This restores the pre-2.0.3 behaviour where `/.auth/login/aad` worked in
+ * local dev without requiring developers to provision a real tenant just to
+ * run the CLI. See https://github.com/Azure/static-web-apps-cli/issues/947.
+ *
+ * Returns `true` iff this is AAD, the config names env vars, and at least one
+ * of them is unset — i.e. the user is clearly in local-dev mode.
+ */
+export const shouldFallbackToAadEmulator = function (providerName: string, customAuth?: SWAConfigFileAuth): boolean {
+  if (providerName !== "aad") {
+    return false;
+  }
+  const registration = customAuth?.identityProviders?.[ENTRAID_FULL_NAME]?.registration;
+  const clientIdSettingName = registration?.clientIdSettingName;
+  const clientSecretSettingName = registration?.clientSecretSettingName;
+  // The config must reference env vars; if either name is missing entirely
+  // that's a config-level error and should surface as 400 (handled below by
+  // `checkCustomAuthConfigFields`).
+  if (!clientIdSettingName || !clientSecretSettingName) {
+    return false;
+  }
+  const clientIdValue = process.env[clientIdSettingName];
+  const clientSecretValue = process.env[clientSecretSettingName];
+  return !clientIdValue || !clientSecretValue;
 };
 
 export const checkCustomAuthConfigFields = function (context: Context, providerName: string, customAuth?: SWAConfigFileAuth) {
@@ -60,6 +93,15 @@ const httpTrigger = async function (context: Context, request: IncomingMessage, 
   await Promise.resolve();
 
   const providerName: string = normalizeAuthProvider(context.bindingData?.provider);
+
+  // Restore pre-2.0.3 behaviour for local dev: if the AAD env vars referenced
+  // by the user's config aren't set, delegate to the local auth emulator
+  // instead of hard-failing. See #947.
+  if (shouldFallbackToAadEmulator(providerName, customAuth)) {
+    logger.silly(`AAD env vars not set — falling back to the SWA local auth emulator for '/.auth/login/aad'`);
+    return authLoginProviderEmulator(context, request);
+  }
+
   const authFields = checkCustomAuthConfigFields(context, providerName, customAuth);
   if (!authFields) {
     return;


### PR DESCRIPTION
## Problem

Two regressions in the custom-auth AAD flow were introduced in 2.0.3 by PR #905. Reported separately as #928, #941, and #947 — this PR fixes the common root causes.

### Regression 1 — `/.auth/login/aad` returns 400 locally

Before 2.0.3, running the CLI against a `staticwebapp.config.json` that declared an AAD custom-auth provider would serve the **local auth emulator** at `/.auth/login/aad` when the referenced env vars were not set. That behaviour is what makes local dev ergonomic: a developer can reuse the production config without provisioning a tenant.

After 2.0.3, `checkCustomAuthConfigFields` hard-fails:

```
400 AAD_CLIENT_ID not found in env for 'aad' provider
```

…which breaks `swa start` for every user whose config targets AAD.

### Regression 2 — `/oauth2/v2.0` issuer URL fails discovery

The deployed SWA runtime accepts `https://login.microsoftonline.com/<tenant>/oauth2/v2.0` as an alias for the canonical `https://login.microsoftonline.com/<tenant>/v2.0`. The CLI’s OIDC discovery (via `openid-client`) does not — it follows redirects from `<issuer>/.well-known/openid-configuration` and ends up in `ERR_TOO_MANY_REDIRECTS`. Users therefore need two different `openIdIssuer` values (one for local, one for prod) which is what #947 describes.

## Root Cause

| # | Where | What changed in #905 |
|---|---|---|
| 1 | `auth-login-provider-custom.ts` → `checkCustomAuthConfigFields` | The emulator fallback path was removed. Every missing env var now produces a 400 with no code path to the local emulator. |
| 2 | `openidHelper.ts` → `OpenIdHelper` ctor | `new URL(issuerUrl)` is passed directly to `client.discovery()` without normalization, so a `/oauth2/v2.0` suffix breaks discovery. |

`src/msha/auth/index.ts` routes `/.auth/login/aad` exclusively to the custom-auth handler when `isCustomAuth=true`, so URL-level fallback is not possible — the delegation must happen in-process.

## Fix

| File | Change |
|---|---|
| `src/core/utils/openidHelper.ts` | Add `export function normalizeOpenIdIssuer(url)` that rewrites a trailing `/oauth2/v2.0` to `/v2.0`. Wire it into the `OpenIdHelper` constructor before `new URL(...)`. Covers `login.microsoftonline.com`, `*.ciamlogin.com`, and Entra custom URL domains. |
| `src/msha/auth/routes/auth-login-provider-custom.ts` | Add `shouldFallbackToAadEmulator(providerName, customAuth)` — returns `true` only when provider is `aad`, the config declares both setting names, **and** at least one referenced env var is unset (i.e. clearly a local-dev case). Delegate to `authLoginProviderEmulator` in `httpTrigger` before `checkCustomAuthConfigFields`. |

Design notes:

- **`checkCustomAuthConfigFields` is unchanged.** It is also used by `auth-login-provider-callback.ts`, which must keep strict 400 semantics — a callback with a real OAuth code has no legitimate reason to fall back to the emulator. Placing the pre-check in the `httpTrigger` caller avoids coupling the two code paths.
- **Config errors still surface as 400.** If `clientIdSettingName` or `clientSecretSettingName` is missing from the config file entirely (as opposed to referenced-but-unset env vars), we fall through to the existing 400 response. Test case (e) covers this.

## Testing

All new and existing tests pass against Node 20.18.0.

```
Test Files  34 passed (34)
     Tests  502 passed | 14 skipped (516)
```

New tests (17):

| Spec file | Cases |
|---|---|
| `src/core/utils/openidHelper.spec.ts` | 12 — `normalizeOpenIdIssuer` correctness across tenant-id / common / organizations, ciamlogin.com, custom Entra domains, canonical URLs preserved, trailing slash preserved, unrelated URLs untouched |
| `src/msha/auth/routes/auth-login-provider-custom.spec.ts` | 5 — emulator fallback when clientId unset / secret unset / both unset; real-auth path when both set; still-400 when config field is missing |

Manual repro of #947 locally:

1. `staticwebapp.config.json` with `openIdIssuer` = `https://login.microsoftonline.com/<tenant>/oauth2/v2.0` and env vars unset.
2. Before: `GET /.auth/login/aad` → 400 `AAD_CLIENT_ID not found in env`.
3. After: `GET /.auth/login/aad` → local auth emulator HTML (same as pre-2.0.3).

## References

- Fixes #947, #928, #941
- Regression introduced by #905 (2.0.3)
- Intended to land after the 2.0.9 release cut in #991 so the fix can be shipped as 2.0.10 without further delaying 2.0.9.
