### PR TITLE
fix: validate --env is not passed with an empty string

### DIFF
--- a/src/cli/commands/deploy/deploy.spec.ts
+++ b/src/cli/commands/deploy/deploy.spec.ts
@@ -313,7 +313,7 @@ describe("deploy", () => {
         outputLocation: "/test-output",
         env: "",
       });
-      expect(logger.error).toHaveBeenNthCalledWith(1, "Invalid --env: cannot be empty. Use 'preview' or omit the flag.");
+      expect(logger.error).toHaveBeenNthCalledWith(1, "Invalid --env: cannot be empty. Use a named environment (e.g. 'preview') or omit the flag.");
     });
   });
 });

--- a/src/cli/commands/deploy/deploy.spec.ts
+++ b/src/cli/commands/deploy/deploy.spec.ts
@@ -307,5 +307,13 @@ describe("deploy", () => {
       expect(env.FUNCTION_LANGUAGE_VERSION).toBe(DEFAULT_VERSION.DotnetIsolated);
       expect(SUPPORTED_VERSIONS.DotnetIsolated).toContain(env.FUNCTION_LANGUAGE_VERSION);
     });
+
+    it("should print an error when --env is an empty string", async () => {
+      await deploy({
+        outputLocation: "/test-output",
+        env: "",
+      });
+      expect(logger.error).toHaveBeenNthCalledWith(1, "Invalid --env: cannot be empty. Use 'preview' or omit the flag.");
+    });
   });
 });

--- a/src/cli/commands/deploy/deploy.ts
+++ b/src/cli/commands/deploy/deploy.ts
@@ -255,6 +255,10 @@ export async function deploy(options: SWACLIConfig) {
   // set the DEPLOYMENT_ENVIRONMENT env variable only when the user has provided
   // a deployment environment which is not "production".
   if (options.env?.toLowerCase() !== "production" && options.env?.toLowerCase() !== "prod") {
+    if (options.env !== undefined && !options.env.trim()) {
+      logger.error("Invalid --env: cannot be empty. Use 'preview' or omit the flag.");
+      return;
+    }
     deployClientEnv.DEPLOYMENT_ENVIRONMENT = options.env;
   }
 

--- a/src/cli/commands/deploy/deploy.ts
+++ b/src/cli/commands/deploy/deploy.ts
@@ -113,6 +113,12 @@ export async function deploy(options: SWACLIConfig) {
       Assuming default version "${apiVersion}"`);
   }
 
+  // make sure --env is not an empty string
+  if (options.env !== undefined && !options.env.trim()) {
+    logger.error("Invalid --env: cannot be empty. Use a named environment (e.g. 'preview') or omit the flag.");
+    return;
+  }
+
   // resolve the deployment token
   if (deploymentToken) {
     deploymentToken = deploymentToken;
@@ -255,10 +261,6 @@ export async function deploy(options: SWACLIConfig) {
   // set the DEPLOYMENT_ENVIRONMENT env variable only when the user has provided
   // a deployment environment which is not "production".
   if (options.env?.toLowerCase() !== "production" && options.env?.toLowerCase() !== "prod") {
-    if (options.env !== undefined && !options.env.trim()) {
-      logger.error("Invalid --env: cannot be empty. Use 'preview' or omit the flag.");
-      return;
-    }
     deployClientEnv.DEPLOYMENT_ENVIRONMENT = options.env;
   }
 

--- a/src/cli/commands/deploy/deploy.ts
+++ b/src/cli/commands/deploy/deploy.ts
@@ -60,6 +60,12 @@ export async function deploy(options: SWACLIConfig) {
     }
   }
 
+  // make sure --env is not an empty string
+  if (options.env !== undefined && !options.env.trim()) {
+    logger.error("Invalid --env: cannot be empty. Use a named environment (e.g. 'preview') or omit the flag.");
+    return;
+  }
+
   logger.silly(`Resolving outputLocation=${outputLocation} full path...`);
   let resolvedOutputLocation = path.resolve(appLocation, outputLocation as string);
 
@@ -111,12 +117,6 @@ export async function deploy(options: SWACLIConfig) {
     apiVersion = getDefaultVersion(apiLanguage);
     logger.log(`Api language "${apiLanguage}" is provided but api version is not provided.
       Assuming default version "${apiVersion}"`);
-  }
-
-  // make sure --env is not an empty string
-  if (options.env !== undefined && !options.env.trim()) {
-    logger.error("Invalid --env: cannot be empty. Use a named environment (e.g. 'preview') or omit the flag.");
-    return;
   }
 
   // resolve the deployment token


### PR DESCRIPTION
Looks like the CLI accepts --env="", and the deployment seems to "work"; There were no error messages in the console at least.
Looking at the portal it doesn't seem like anything gets deployed however.

I am not exactly sure how I could dig deeper into what happens when the deployment code is actually running, but I guess adding this extra validation can't hurt.