### PR TITLE
fix supported versions

### DIFF
--- a/schema/staticwebapp.config.json
+++ b/schema/staticwebapp.config.json
@@ -588,6 +588,7 @@
             "dotnet:8.0",
             "dotnet-isolated:8.0",
             "dotnet-isolated:9.0",
+            "dotnet-isolated:10.0",
             "node:18",
             "node:20",
             "node:22",

--- a/src/cli/commands/deploy/deploy.ts
+++ b/src/cli/commands/deploy/deploy.ts
@@ -37,6 +37,11 @@ export async function deploy(options: SWACLIConfig) {
     apiVersion,
   } = options;
 
+  // normalize the hyphenated variant to the canonical value used throughout the codebase
+  if (apiLanguage === "dotnet-isolated") {
+    apiLanguage = "dotnetisolated";
+  }
+
   if (dryRun) {
     logger.warn("***********************************************************************");
     logger.warn("* WARNING: Running in dry run mode. This project will not be deployed *");

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -305,7 +305,7 @@ export const DEFAULT_VERSION = {
 };
 
 export const SUPPORTED_VERSIONS = {
-  Node: ["18", "20", "22", "24", "26"],
+  Node: ["18", "20", "22"],
   Dotnet: ["8.0"],
   DotnetIsolated: ["8.0", "9.0", "10.0"],
   Python: ["3.9", "3.10", "3.11"],

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -305,9 +305,9 @@ export const DEFAULT_VERSION = {
 };
 
 export const SUPPORTED_VERSIONS = {
-  Node: ["18", "20", "22"],
+  Node: ["18", "20", "22", "24", "26"],
   Dotnet: ["8.0"],
-  DotnetIsolated: ["8.0", "9.0"],
+  DotnetIsolated: ["8.0", "9.0", "10.0"],
   Python: ["3.9", "3.10", "3.11"],
 };
 


### PR DESCRIPTION
It is a mistery to my why the cli is only supporting very old versions. Here is a version bump for node an `dotnet-isolated` which for some reason are referenced as `dotnetisolated` only in this repository.

And you might want to change the config specification to also reflect this..... [schemastore.org/staticwebapp.config.json](https://www.schemastore.org/staticwebapp.config.json)

<img width="598" height="415" alt="image" src="https://github.com/user-attachments/assets/d72ee679-35e6-43a8-a7cb-5b0476bb5092" />

```json
{
    "platform": {
      "type": "object",
      "description": "Platform configuration",
      "properties": {
        "apiRuntime": {
          "type": "string",
          "enum": [
            "dotnet:3.1",
            "dotnet:6.0",
            "dotnet-isolated:6.0",
            "dotnet-isolated:7.0",
            "dotnet-isolated:8.0",
            "dotnet-isolated:9.0",
            "node:12",
            "node:14",
            "node:16",
            "node:18",
            "node:20",
            "python:3.8",
            "python:3.9",
            "python:3.10"
          ],
          "description": "Language runtime for the managed functions API"
        }
      },
      "additionalProperties": false
    },
}
```