### PR TITLE
fix: fx CLI docs deployment workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,5 +24,5 @@ jobs:
           npm ci
           npm run deploy
         env:
-          GIT_PASS: ${{ secrets.GITHUB_TOKEN }}
-          GIT_USER: ${{ github.actor }}
+          GIT_PASS: ${{ secrets.SWA_CLI_DEPLOY_DOCS_GH_PAGES }}
+          GIT_USER: "cjk7989"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,6 +8,8 @@ jobs:
   build_and_deploy_job:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - run: git config --global user.email "github@wassim.dev"
@@ -22,5 +24,5 @@ jobs:
           npm ci
           npm run deploy
         env:
-          GIT_PASS: ${{ secrets.SWA_CLI_DEPLOY_DOCS_GH_PAGES }}
-          GIT_USER: "manekinekko"
+          GIT_PASS: ${{ secrets.GITHUB_TOKEN }}
+          GIT_USER: ${{ github.actor }}


### PR DESCRIPTION
## Summary

- Add a manual trigger for the CLI docs deployment workflow
- Update the deployment credentials to use the current maintainer account
- Restore publishing to the `gh-pages` branch

## Validation

- Manually triggered the workflow from the development branch
- Confirmed the documentation was successfully published